### PR TITLE
fix to missile trainer be 132nd

### DIFF
--- a/Moose Development/Moose/Functional/MissileTrainer.lua
+++ b/Moose Development/Moose/Functional/MissileTrainer.lua
@@ -502,6 +502,10 @@ function MISSILETRAINER:_EventShot( Event )
   else
      -- TODO: some weapons don't know the target unit... Need to develop a workaround for this.
     SCHEDULER:New( TrainerWeapon, TrainerWeapon.destroy, {}, 2 )
+		if ( TrainerWeapon:getTypeName() == "9M311" ) then
+		SCHEDULER:New( TrainerWeapon, TrainerWeapon.destroy, {}, 2 )
+		else
+		end
   end
 end
 

--- a/Moose Mission Setup/Moose.lua
+++ b/Moose Mission Setup/Moose.lua
@@ -21673,6 +21673,10 @@ function MISSILETRAINER:_EventShot( Event )
   else
      -- TODO: some weapons don't know the target unit... Need to develop a workaround for this.
     SCHEDULER:New( TrainerWeapon, TrainerWeapon.destroy, {}, 2 )
+		if ( TrainerWeapon:getTypeName() == "9M311" ) then
+		SCHEDULER:New( TrainerWeapon, TrainerWeapon.destroy, {}, 2 )
+		else
+		end
   end
 end
 


### PR DESCRIPTION
we had noticed that some weapons, like GBU-38 were destroyed by the
missile trainer. This insert would restrict the unspecific destruction
of weapons to the Tunguskas missile only and leave other weapons, like
GBU38 intact