### PR TITLE
initCleanup taken out of this demo mission

### DIFF
--- a/Moose Test Missions/AIB - AI Balancing/AIB-005 - Patrol AI and Randomize Zones/AIB-005 - Patrol AI and Randomize Zones.lua
+++ b/Moose Test Missions/AIB - AI Balancing/AIB-005 - Patrol AI and Randomize Zones/AIB-005 - Patrol AI and Randomize Zones.lua
@@ -23,8 +23,6 @@
 local RU_PlanesClientSet = SET_CLIENT:New():FilterCountries( "RUSSIA" ):FilterCategories( "plane" )
 
 -- Define the SPAWN object for the red AI plane template.
--- We use InitCleanUp to check every 20 seconds, if there are no planes blocked at the airbase, waithing for take-off.
--- If a blocked plane exists, this red plane will be ReSpawned.
 local RU_PlanesSpawn = SPAWN:New( "AI RU" )
 
 -- Start the AI_BALANCER, using the SET of red CLIENTs, and the SPAWN object as a parameter.


### PR DESCRIPTION
Looks like initCleanup was taken out of this demo mission and moved to its own declutter AI test mission. Just removing the comment as it no longer applies here.