### PR TITLE
Add optional AmmoCount to CONTROLLABLE:TaskFireAtPoint

### DIFF
--- a/Moose Development/Moose/Wrapper/Controllable.lua
+++ b/Moose Development/Moose/Wrapper/Controllable.lua
@@ -39,7 +39,7 @@
 --   * @{#CONTROLLABLE.TaskEmbarkToTransport}: (GROUND) Embark to a Transport landed at a location.
 --   * @{#CONTROLLABLE.TaskEscort}: (AIR) Escort another airborne controllable. 
 --   * @{#CONTROLLABLE.TaskFAC_AttackControllable}: (AIR + GROUND) The task makes the controllable/unit a FAC and orders the FAC to control the target (enemy ground controllable) destruction.
---   * @{#CONTROLLABLE.TaskFireAtPoint}: (GROUND) Fire at a VEC2 point until ammunition is finished.
+--   * @{#CONTROLLABLE.TaskFireAtPoint}: (GROUND) Fire some or all ammunition at a VEC2 point.
 --   * @{#CONTROLLABLE.TaskFollow}: (AIR) Following another airborne controllable.
 --   * @{#CONTROLLABLE.TaskHold}: (GROUND) Hold ground controllable from moving.
 --   * @{#CONTROLLABLE.TaskHoldPosition}: (AIR) Hold position at the current position of the first unit of the controllable.
@@ -947,9 +947,10 @@ end
 -- @param #CONTROLLABLE self
 -- @param Dcs.DCSTypes#Vec2 Vec2 The point to fire at.
 -- @param Dcs.DCSTypes#Distance Radius The radius of the zone to deploy the fire at.
+-- @param #number AmmoCount (optional) Quantity of ammunition to expand (omit to fire until ammunition is depleted).
 -- @return Dcs.DCSTasking.Task#Task The DCS task structure.
-function CONTROLLABLE:TaskFireAtPoint( Vec2, Radius )
-  self:F2( { self.ControllableName, Vec2, Radius } )
+function CONTROLLABLE:TaskFireAtPoint( Vec2, Radius, AmmoCount )
+  self:F2( { self.ControllableName, Vec2, Radius, AmmoCount } )
 
   -- FireAtPoint = {
   --   id = 'FireAtPoint',
@@ -966,10 +967,15 @@ function CONTROLLABLE:TaskFireAtPoint( Vec2, Radius )
     params = {
       point = Vec2,
       radius = Radius,
-      expendQty = 100,  -- added both parameters to override the bug the apparent custome value of expendQty = 1 and expendQty = true
-      expendQtyEnabled = false, --  -- added both parameters to override the bug the apparent custome value of expendQty = 1 and expendQty = true
+      expendQty = 100, -- dummy value
+      expendQtyEnabled = false,
     }
   }
+  
+  if AmmoCount then
+    DCSTask.params.expendQty = AmmoCount
+    DCSTask.params.expendQtyEnabled = true
+  end
 
   self:T3( { DCSTask } )
   return DCSTask

--- a/Moose Mission Setup/Moose.lua
+++ b/Moose Mission Setup/Moose.lua
@@ -12549,7 +12549,7 @@ end
 --   * @{#CONTROLLABLE.TaskEmbarkToTransport}: (GROUND) Embark to a Transport landed at a location.
 --   * @{#CONTROLLABLE.TaskEscort}: (AIR) Escort another airborne controllable. 
 --   * @{#CONTROLLABLE.TaskFAC_AttackControllable}: (AIR + GROUND) The task makes the controllable/unit a FAC and orders the FAC to control the target (enemy ground controllable) destruction.
---   * @{#CONTROLLABLE.TaskFireAtPoint}: (GROUND) Fire at a VEC2 point until ammunition is finished.
+--   * @{#CONTROLLABLE.TaskFireAtPoint}: (GROUND) Fire some or all ammunition at a VEC2 point.
 --   * @{#CONTROLLABLE.TaskFollow}: (AIR) Following another airborne controllable.
 --   * @{#CONTROLLABLE.TaskHold}: (GROUND) Hold ground controllable from moving.
 --   * @{#CONTROLLABLE.TaskHoldPosition}: (AIR) Hold position at the current position of the first unit of the controllable.
@@ -13457,9 +13457,10 @@ end
 -- @param #CONTROLLABLE self
 -- @param Dcs.DCSTypes#Vec2 Vec2 The point to fire at.
 -- @param Dcs.DCSTypes#Distance Radius The radius of the zone to deploy the fire at.
+-- @param #number AmmoCount (optional) Quantity of ammunition to expand (omit to fire until ammunition is depleted).
 -- @return Dcs.DCSTasking.Task#Task The DCS task structure.
-function CONTROLLABLE:TaskFireAtPoint( Vec2, Radius )
-  self:F2( { self.ControllableName, Vec2, Radius } )
+function CONTROLLABLE:TaskFireAtPoint( Vec2, Radius, AmmoCount )
+  self:F2( { self.ControllableName, Vec2, Radius, AmmoCount } )
 
   -- FireAtPoint = {
   --   id = 'FireAtPoint',
@@ -13476,10 +13477,15 @@ function CONTROLLABLE:TaskFireAtPoint( Vec2, Radius )
     params = {
       point = Vec2,
       radius = Radius,
-      expendQty = 100,  -- added both parameters to override the bug the apparent custome value of expendQty = 1 and expendQty = true
-      expendQtyEnabled = false, --  -- added both parameters to override the bug the apparent custome value of expendQty = 1 and expendQty = true
+      expendQty = 100, -- dummy value
+      expendQtyEnabled = false,
     }
   }
+  
+  if AmmoCount then
+	DCSTask.params.expendQty = AmmoCount
+	DCSTask.params.expendQtyEnabled = true
+  end
 
   self:T3( { DCSTask } )
   return DCSTask


### PR DESCRIPTION
I've added an optional parameters to the FireAtPoint function. This parameter controls the number of ammunition that should be expanded during the Task.

A test mission along with a test script can be found at: https://github.com/132nd-etcher/MOOSE/releases/tag/v0.4.0-alpha