### PR TITLE
Bugs/issue 292

### DIFF
--- a/Moose Development/Moose/Core/Point.lua
+++ b/Moose Development/Moose/Core/Point.lua
@@ -586,9 +586,9 @@ function POINT_VEC3:RoutePointAir( AltType, Type, Action, Speed, SpeedLocked )
   self:F2( { AltType, Type, Action, Speed, SpeedLocked } )
 
   local RoutePoint = {}
-  RoutePoint.x = self:GetX()
-  RoutePoint.y = self:GetZ()
-  RoutePoint.alt = self:GetY()
+  RoutePoint.x = self:GetLat()   -- Not sure if this is really necessary but it is clearer
+  RoutePoint.y = self:GetLon()   -- Not sure if this is really necessary but it is clearer
+  RoutePoint.alt = self:GetAlt() -- This is the tricky bit
   RoutePoint.alt_type = AltType
   
   RoutePoint.type = Type
@@ -627,8 +627,9 @@ function POINT_VEC3:RoutePointGround( Speed, Formation )
   self:F2( { Formation, Speed } )
 
   local RoutePoint = {}
-  RoutePoint.x = self:GetX()
-  RoutePoint.y = self:GetZ()
+  RoutePoint.x = self:GetLat()   -- Not sure if this is really necessary but it is clearer
+  RoutePoint.y = self:GetLon()   -- Not sure if this is really necessary but it is clearer
+  -- Should RoutePoint.alt not be set? Or is a nil value for RoutePoint.alt handled whereever it is used?
   
   RoutePoint.action = Formation or ""
     

--- a/Moose Development/Moose/Core/Point.lua
+++ b/Moose Development/Moose/Core/Point.lua
@@ -420,7 +420,7 @@ function POINT_VEC3:GetRandomVec3InRadius( OuterRadius, InnerRadius )
 
   local RandomVec2 = self:GetRandomVec2InRadius( OuterRadius, InnerRadius )
   local y = self:GetY() + math.random( InnerRadius, OuterRadius )
-  local RandomVec3 = { x = RandomVec2.x, y = y, z = RandomVec2.z }
+  local RandomVec3 = { x = RandomVec2.x, y = y, z = RandomVec2.z } -- ERROR? Should this be z = RandomVec2.y? Since RandomVec2 is a Vec2 
 
   return RandomVec3
 end

--- a/Moose Development/Moose/Core/Point.lua
+++ b/Moose Development/Moose/Core/Point.lua
@@ -20,6 +20,7 @@
 -- Methods exist to manupulate these coordinates.
 -- 
 -- The current X, Y, Z axis can be retrieved with the methods @{#POINT_VEC3.GetX}(), @{#POINT_VEC3.GetY}(), @{#POINT_VEC3.GetZ}() respectively.
+-- The current Lat(itude), Alt(itude), Lon(gitude) values can also be retrieved with the methods @{#POINT_VEC3.GetLat}(), @{#POINT_VEC3.GetAlt}(), @{#POINT_VEC3.GetLon}() respectively.
 -- The methods @{#POINT_VEC3.SetX}(), @{#POINT_VEC3.SetY}(), @{#POINT_VEC3.SetZ}() change the respective axis with a new value.
 -- The current axis values can be changed by using the methods @{#POINT_VEC3.AddX}(), @{#POINT_VEC3.AddY}(), @{#POINT_VEC3.AddZ}()
 -- to add or substract a value from the current respective axis value.
@@ -80,6 +81,7 @@
 -- 
 -- The current X, Altitude, Y axis can be retrieved with the methods @{#POINT_VEC2.GetX}(), @{#POINT_VEC2.GetAlt}(), @{#POINT_VEC2.GetY}() respectively.
 -- The methods @{#POINT_VEC2.SetX}(), @{#POINT_VEC2.SetAlt}(), @{#POINT_VEC2.SetY}() change the respective axis with a new value.
+-- The method @{#POINT_VEC2.GetGroundAlt}() will return the height of the ground at the current X and Y locations. 
 -- The current axis values can be changed by using the methods @{#POINT_VEC2.AddX}(), @{#POINT_VEC2.AddAlt}(), @{#POINT_VEC2.AddY}()
 -- to add or substract a value from the current respective axis value.
 -- Note that the Set and Add methods return the current POINT_VEC2 object, so these manipulation methods can be chained... For example:
@@ -258,6 +260,34 @@ function POINT_VEC3:GetZ()
   return self.z
 end
 
+--- Return the Lat(itude) coordinate of the POINT_VEC3 (ie: POINT_VEC3.x).
+-- @param #POINT_VEC3 self
+-- @return #number The x coodinate.
+function POINT_VEC3:GetLat()
+  return self.x
+end
+
+--- Return the Alt(itude) coordinate of the POINT_VEC3 (ie: POINT_VEC3.y).
+-- @param #POINT_VEC3 self
+-- @return #number The y coodinate.
+function POINT_VEC3:GetAlt()
+  return self.y
+end
+
+--- Return the Lon(gitude) coordinate of the POINT_VEC3 (ie: POINT_VEC3.z).
+-- @param #POINT_VEC3 self
+-- @return #number The z coodinate.
+function POINT_VEC3:GetLon()
+  return self.z
+end
+
+--- Return the altitude (height) of the land at the POINT_VEC3.
+-- @param #POINT_VEC3 self
+-- @return #number The h value.
+function POINT_VEC3:GetGroundAlt()
+  return land.getHeight( { x = self.x, y = self.z } )
+end
+
 --- Set the x coordinate of the POINT_VEC3.
 -- @param #POINT_VEC3 self
 -- @param #number x The x coordinate.
@@ -281,6 +311,33 @@ end
 -- @param #number z The z coordinate.
 -- @return #POINT_VEC3
 function POINT_VEC3:SetZ( z )
+  self.z = z
+  return self
+end
+
+--- Set the Lat(itude) coordinate of the POINT_VEC3 (ie: POINT_VEC3.x).
+-- @param #POINT_VEC3 self
+-- @param #number x The x coordinate (Latitude for Vec2/Vec3).
+-- @return #POINT_VEC3
+function POINT_VEC3:SetLat( x )
+  self.x = x
+  return self
+end
+
+--- Set the Alt(itude) coordinate of the POINT_VEC3 (ie: POINT_VEC3.y).
+-- @param #POINT_VEC3 self
+-- @param #number y The y coordinate (Altitude for Vec3).
+-- @return #POINT_VEC3
+function POINT_VEC3:SetAlt( Altitude )
+  self.y = Altitude or land.getHeight( { x = self.x, y = self.z } )
+  return self
+end
+
+--- Set the Lon(gitude) coordinate of the POINT_VEC3 (ie: POINT_VEC3.z).
+-- @param #POINT_VEC3 self
+-- @param #number z The z coordinate Longitude for Vec3).
+-- @return #POINT_VEC3
+function POINT_VEC3:SetLon( z )
   self.z = z
   return self
 end
@@ -772,11 +829,32 @@ function POINT_VEC2:GetY()
   return self.z
 end
 
---- Return the altitude of the land at the POINT_VEC2.
+--- Return the altitude (height) of the land at the POINT_VEC2.
+-- @param #POINT_VEC2 self
+-- @return #number The land altitude.
+function POINT_VEC2:GetGroundAlt()
+  return land.getHeight( { x = self.x, y = self.z } )
+end
+
+--- Return Return the Lat(itude) coordinate of the POINT_VEC2 (ie: (parent)POINT_VEC3.x).
+-- @param #POINT_VEC2 self
+-- @return #number The x coodinate.
+function POINT_VEC2:GetLat()
+  return self.x
+end
+
+--- Return the Alt(itude) coordinate of the (parent) POINT_VEC3 (ie: (parent)POINT_VEC3.y).
 -- @param #POINT_VEC2 self
 -- @return #number The land altitude.
 function POINT_VEC2:GetAlt()
-  return land.getHeight( { x = self.x, y = self.z } )
+  return self.y
+end
+
+--- Return the Lon(gitude) coordinate of the POINT_VEC2 (ie: (parent)POINT_VEC3.z).
+-- @param #POINT_VEC2 self
+-- @return #number The y coodinate.
+function POINT_VEC2:GetLon()
+  return self.z
 end
 
 --- Set the x coordinate of the POINT_VEC2.
@@ -797,12 +875,31 @@ function POINT_VEC2:SetY( y )
   return self
 end
 
+--- Set the Lat(itude) coordinate of the POINT_VEC2 (ie: POINT_VEC3.x).
+-- @param #POINT_VEC2 self
+-- @param #number x The x coordinate.
+-- @return #POINT_VEC2
+function POINT_VEC2:SetLat( x )
+  self.x = x
+  return self
+end
+
+
 --- Set the altitude of the POINT_VEC2.
 -- @param #POINT_VEC2 self
 -- @param #number Altitude The land altitude. If nothing (nil) is given, then the current land altitude is set.
 -- @return #POINT_VEC2
 function POINT_VEC2:SetAlt( Altitude )
   self.y = Altitude or land.getHeight( { x = self.x, y = self.z } )
+  return self
+end
+
+--- Set the Lon(gitude) coordinate of the POINT_VEC2 (ie: POINT_VEC3.z).
+-- @param #POINT_VEC2 self
+-- @param #number y The y coordinate.
+-- @return #POINT_VEC2
+function POINT_VEC2:SetLon( y )
+  self.z = y
   return self
 end
 


### PR DESCRIPTION
This should fix the problem with the RoutePoints in POINT_VEC3:RoutePointAir().

In short, the RoutePoint.alt = self:GetAlt() call is the crux of the fix, ensuring that we are getting the altitude values from either POINT_VEC2 or POINT_VEC3. All of the other changes are to maintain consistency of these calls between both objects. I added GetLat() and GetLon() calls for a little clarity although they are not different from the original GetX and GetY/GetZ calls.

The biggest significant change is that POINT_VEC2:GetAlt changed from returning the calculated land height to the LandHeight + LandHeightAdd that was passed in the POINT_VEC2:New() calls. I added GetGroundAlt() to both POINT_VEC2 and POINT_VEC3 is case some mission designer needed a function similar to the old way POINT_VEC2:GetAlt() worked.

NOTE: There is a potential bug on line 423:
`local RandomVec3 = { x = RandomVec2.x, y = y, z = RandomVec2.z } -- ERROR? Should this be z = RandomVec2.y? Since RandomVec2 is a Vec2` 