### PR TITLE
issue #433

### DIFF
--- a/Moose Development/Moose/Core/Cargo.lua
+++ b/Moose Development/Moose/Core/Cargo.lua
@@ -697,7 +697,7 @@ function CARGO_UNIT:onenterBoarding( From, Event, To, CargoCarrier, NearRadius, 
   
   NearRadius = NearRadius or 25
 
-  if From == "UnLoaded" then
+  if From == "UnLoaded" or "Boarding" then
     local CargoCarrierPointVec2 = CargoCarrier:GetPointVec2()
     local CargoCarrierHeading = CargoCarrier:GetHeading() -- Get Heading of object in degrees.
     local CargoDeployHeading = ( ( CargoCarrierHeading + Angle ) >= 360 ) and ( CargoCarrierHeading + Angle - 360 ) or ( CargoCarrierHeading + Angle )
@@ -730,7 +730,7 @@ function CARGO_UNIT:onenterBoarding( From, Event, To, CargoCarrier, NearRadius, 
     end
 
     local TaskRoute = self.CargoObject:TaskRoute( Points )
-    self.CargoObject:SetTask( TaskRoute, 2 )
+    self.CargoObject:GetGroup():SetTask( TaskRoute, 2 )
   end
   
 end


### PR DESCRIPTION
CARGO_UNIT fsm now calls for a new taskroute as long as boarding is not
yet finished.

the tasking is given to the units group, for dcs reasons.