### PR TITLE
Publishing new Menu driven reporting structure for TASKING

### DIFF
--- a/Moose Development/Moose/Functional/Detection.lua
+++ b/Moose Development/Moose/Functional/Detection.lua
@@ -1172,6 +1172,7 @@ do -- DETECTION_BASE
     
     DetectedItem.Set = Set or SET_UNIT:New():FilterDeads():FilterCrashes()
     DetectedItem.ItemID = ItemPrefix .. "." .. self.DetectedItemMax
+    DetectedItem.ID = self.DetectedItemMax
     DetectedItem.Removed = false
     
     return DetectedItem
@@ -1239,11 +1240,25 @@ do -- DETECTION_BASE
   -- @param #DETECTION_BASE self
   -- @param #number Index
   -- @return #string DetectedItemID
-  function DETECTION_BASE:GetDetectedItemID( Index )
+  function DETECTION_BASE:GetDetectedItemID( Index ) --R2.1
   
     local DetectedItem = self.DetectedItems[Index]
     if DetectedItem then
       return DetectedItem.ItemID
+    end
+    
+    return ""
+  end
+  
+  --- Get a detected ID using a given numeric index.
+  -- @param #DETECTION_BASE self
+  -- @param #number Index
+  -- @return #string DetectedItemID
+  function DETECTION_BASE:GetDetectedID( Index ) --R2.1
+  
+    local DetectedItem = self.DetectedItems[Index]
+    if DetectedItem then
+      return DetectedItem.ID
     end
     
     return ""

--- a/Moose Development/Moose/Tasking/CommandCenter.lua
+++ b/Moose Development/Moose/Tasking/CommandCenter.lua
@@ -162,6 +162,8 @@ function COMMANDCENTER:New( CommandCenterPositionable, CommandCenterName )
       end
     end
   )
+  
+  self:SetMenu()
 	
 	return self
 end
@@ -220,12 +222,12 @@ function COMMANDCENTER:SetMenu()
   self.CommandCenterMenu = self.CommandCenterMenu or MENU_COALITION:New( self.CommandCenterCoalition, "Command Center (" .. self:GetName() .. ")" )
 
   local MenuTime = timer.getTime()
-  for MissionID, Mission in pairs( self:GetMissions() ) do
+  for MissionID, Mission in pairs( self:GetMissions() or {} ) do
     local Mission = Mission -- Tasking.Mission#MISSION
     Mission:SetMenu( MenuTime )
   end
 
-  for MissionID, Mission in pairs( self:GetMissions() ) do
+  for MissionID, Mission in pairs( self:GetMissions() or {} ) do
     local Mission = Mission -- Tasking.Mission#MISSION
     Mission:RemoveMenu( MenuTime )
   end


### PR DESCRIPTION
-- Each group can now select from a menu to report a task overview or
only the task with a specific state...
-- Dactivate the flashing of the available tasks. A small message is
displayed now.