### PR TITLE
Fixed issue #480

### DIFF
--- a/Moose Development/Moose/Tasking/CommandCenter.lua
+++ b/Moose Development/Moose/Tasking/CommandCenter.lua
@@ -9,6 +9,7 @@
 -- @extends Core.Base#BASE
 REPORT = {
   ClassName = "REPORT",
+  Title = "",
 }
 
 --- Create a new REPORT.
@@ -20,12 +21,23 @@ function REPORT:New( Title )
   local self = BASE:Inherit( self, BASE:New() ) -- #REPORT
 
   self.Report = {}
+  
+  Title = Title or ""
   if Title then
-    self.Report[#self.Report+1] = Title  
+    self.Title = Title  
   end
 
   return self
 end
+
+--- Has the REPORT Text?
+-- @param #REPORT self
+-- @return #boolean
+function REPORT:HasText() --R2.1
+  
+  return #self.Report > 0
+end
+
 
 --- Set indent of a REPORT.
 -- @param #REPORT self
@@ -61,7 +73,7 @@ end
 -- @return #string The report text.
 function REPORT:Text( Delimiter )
   Delimiter = Delimiter or "\n"
-  local ReportText = table.concat( self.Report, Delimiter ) or ""
+  local ReportText = ( self.Title ~= "" and self.Title .. Delimiter or self.Title ) .. table.concat( self.Report, Delimiter ) or ""
   return ReportText
 end
 


### PR DESCRIPTION
-- The logic has been reviewed
-- There is now a direct link between the Detection ID and the Task in the A2G_TASK_DISPATCHER.
- The Task is searched by Detection ID. Thus, any task with a different name but already existing is either removed and re-added, or, left untouched. So, a BAI task will stay a BAI task if the task has been assigned to a group.
- If a Task is Planned, it will be evaluated to be deleted, but only then. Any other status will keep the task.
- Improved the message appearing of the available tasks of a Mission after a detection run.