### PR TITLE
Fix Missile Distance Message in Missile Trainer Menu

### DIFF
--- a/Moose Development/Moose/Functional/MissileTrainer.lua
+++ b/Moose Development/Moose/Functional/MissileTrainer.lua
@@ -442,7 +442,7 @@ function MISSILETRAINER._MenuMessages( MenuParameters )
 
   if MenuParameters.Distance ~= nil then
     self.Distance = MenuParameters.Distance
-    MESSAGE:New( "Hit detection distance set to " .. self.Distance .. " meters", 15, "Menu" ):ToAll()
+    MESSAGE:New( "Hit detection distance set to " .. self.Distance * 1000 .. " meters", 15, "Menu" ):ToAll()
   end
 
 end


### PR DESCRIPTION
The confirmation Message in the Missile Trainer Menu said:

" Hit detection distance set to 0.2 meters " (instead of 200 meters)