### PR TITLE
Mission complete disabled when a task is finished

### DIFF
--- a/Moose Development/Moose/Tasking/Task.lua
+++ b/Moose Development/Moose/Tasking/Task.lua
@@ -1174,7 +1174,7 @@ function TASK:onenterSuccess( From, Event, To )
   self:GetMission():GetCommandCenter():MessageToCoalition( "Task " .. self:GetName() .. " is successful! Good job!" )
   self:UnAssignFromGroups()
   
-  self:GetMission():__Complete( 1 )
+  --self:GetMission():__Complete( 1 )
   
 end
 


### PR DESCRIPTION
The concept was completely wrong. A mission will require separate logic
or triggers to register goal completion. I will need to do a training
video on that one.