### PR TITLE
OnSpawnGroup happening before BIRTH sometimes

### DIFF
--- a/Moose Development/Moose/Functional/Spawn.lua
+++ b/Moose Development/Moose/Functional/Spawn.lua
@@ -855,7 +855,10 @@ function SPAWN:SpawnWithIndex( SpawnIndex )
 			
 			-- If there is a SpawnFunction hook defined, call it.
 			if self.SpawnFunctionHook then
-			  self.SpawnFunctionHook( self.SpawnGroups[self.SpawnIndex].Group, unpack( self.SpawnFunctionArguments ) )
+			  -- delay calling this for .1 seconds so that it hopefully comes after the BIRTH event of the group.
+			  self.SpawnHookScheduler = SCHEDULER:New()
+			  self.SpawnHookScheduler:Schedule( nil, self.SpawnFunctionHook, { self.SpawnGroups[self.SpawnIndex].Group, unpack( self.SpawnFunctionArguments)}, 0.1 )
+			  -- self.SpawnFunctionHook( self.SpawnGroups[self.SpawnIndex].Group, unpack( self.SpawnFunctionArguments ) )
 			end
 			-- TODO: Need to fix this by putting an "R" in the name of the group when the group repeats.
 			--if self.Repeat then


### PR DESCRIPTION
Add a little bit of a delay in calling the OnSpawnGroup function as it
sometimes happens before the actual BIRTH event of the group.