### PR TITLE
Fix for '-' characters in the prefix string when using FilterPrefix o…

### DIFF
--- a/Moose Development/Moose/Core/Set.lua
+++ b/Moose Development/Moose/Core/Set.lua
@@ -1193,7 +1193,7 @@ function SET_GROUP:IsIncludeObject( MooseGroup )
     local MooseGroupPrefix = false
     for GroupPrefixId, GroupPrefix in pairs( self.Filter.GroupPrefixes ) do
       self:T3( { "Prefix:", string.find( MooseGroup:GetName(), GroupPrefix, 1 ), GroupPrefix } )
-      if string.find( MooseGroup:GetName(), GroupPrefix, 1 ) then
+      if string.find( MooseGroup:GetName(), GroupPrefix:gsub ("-", "%%-"), 1 ) then
         MooseGroupPrefix = true
       end
     end


### PR DESCRIPTION
Fix for '-' characters in the prefix string when using FilterPrefix on groups with '-' in the name.

This should replace '-' characters in the search pattern with %- (the escaped version). The double %% is necessary to get the escape sequence through.