### PR TITLE
Added Knots to Kmph

### DIFF
--- a/Moose Development/Moose/Utilities/Utils.lua
+++ b/Moose Development/Moose/Utilities/Utils.lua
@@ -183,6 +183,10 @@ UTILS.KnotsToMps = function(knots)
   return knots*1852/3600
 end
 
+UTILS.KnotsToKmph = function(knots)
+  return knots* 1.852
+end
+
 UTILS.KmphToMps = function(kmph)
   return kmph/3.6
 end


### PR DESCRIPTION
Adds knots to KM/h to the UTILS to prevent the doubling up of data. 
And addresses #618 