### PR TITLE
Fixes in Cargo

### DIFF
--- a/Moose Development/Moose/Core/Cargo.lua
+++ b/Moose Development/Moose/Core/Cargo.lua
@@ -484,9 +484,11 @@ end
 -- @param #number NearRadius The radius when the cargo will board the Carrier (to avoid collision).
 -- @return #boolean
 function CARGO:IsNear( PointVec2, NearRadius )
-  self:F( { PointVec2, NearRadius } )
+  self:E( { PointVec2, NearRadius } )
+  self:E(self.CargoObject:GetPointVec2())
 
-  local Distance = PointVec2:DistanceFromPointVec2( self.CargoObject:GetPointVec2() )
+  --local Distance = PointVec2:DistanceFromPointVec2( self.CargoObject:GetPointVec2() )
+  local Distance = PointVec2:Get2DDistance( self.CargoObject:GetPointVec2() )
   self:T( Distance )
   
   if Distance <= NearRadius then
@@ -869,9 +871,9 @@ function CARGO_UNIT:onenterUnLoaded( From, Event, To, ToPointVec2 )
     local StartPointVec2 = self.CargoCarrier:GetPointVec2()
     local CargoCarrierHeading = self.CargoCarrier:GetHeading() -- Get Heading of object in degrees.
     local CargoDeployHeading = ( ( CargoCarrierHeading + Angle ) >= 360 ) and ( CargoCarrierHeading + Angle - 360 ) or ( CargoCarrierHeading + Angle )
-    local CargoDeployPointVec2 = StartPointVec2:Translate( Distance, CargoDeployHeading )
+    local CargoDeployCoord = StartPointVec2:Translate( Distance, CargoDeployHeading )
 
-    ToPointVec2 = ToPointVec2 or POINT_VEC2:New( CargoDeployPointVec2:GetX(), CargoDeployPointVec2:GetY() )
+    ToPointVec2 = ToPointVec2 or POINT_VEC2:New( CargoDeployCoord.x, CargoDeployCoord.z )
 
     -- Respawn the group...
     if self.CargoObject then

--- a/Moose Development/Moose/Core/Cargo.lua
+++ b/Moose Development/Moose/Core/Cargo.lua
@@ -484,8 +484,7 @@ end
 -- @param #number NearRadius The radius when the cargo will board the Carrier (to avoid collision).
 -- @return #boolean
 function CARGO:IsNear( PointVec2, NearRadius )
-  self:E( { PointVec2, NearRadius } )
-  self:E(self.CargoObject:GetPointVec2())
+  self:F( { PointVec2, NearRadius } )
 
   --local Distance = PointVec2:DistanceFromPointVec2( self.CargoObject:GetPointVec2() )
   local Distance = PointVec2:Get2DDistance( self.CargoObject:GetPointVec2() )


### PR DESCRIPTION
Translate returns a COORDINATE object. Hence GetX() and GetY() don't work.
DistanceFromPointVec2 should better be replaced by COORDINATE:Get2DDistance.
