### PR TITLE
fix a small issues in EVENT with debug condition

### DIFF
--- a/Moose Development/Moose/Core/Event.lua
+++ b/Moose Development/Moose/Core/Event.lua
@@ -734,7 +734,7 @@ function EVENT:onEvent( Event )
   local ErrorHandler = function( errmsg )
 
     env.info( "Error in SCHEDULER function:" .. errmsg )
-    if debug ~= nil then
+    if BASE.Debug ~= nil then
       env.info( debug.traceback() )
     end
     


### PR DESCRIPTION
```07666.443 INFO    SCRIPTING:   5761(    13)/E:               EVENT00000.onEvent({[1]=S_EVENT_SHOT,[2]={[IniUnit]={[ClassName]=UNIT,[UnitName]=Unit #100,},[IniUnitName]=Unit #100,[time]=39826.546,[IniGroup]={[ClassName]=GROUP,[GroupName]=Training Strela SA9,[Takeoff]={[Air]=1,[Hot]=3,[Runway]=2,[Cold]=4,},},[IniDCSGroupName]=Training Strela SA9,[WeaponName]=9M31,[IniCoalition]=1,[id]=1,[IniObjectCategory]=1,[IniTypeName]=Strela-1 9P31,[IniCategory]=2,[Weapon]={[id_]=16996097,},[IniGroupName]=Training Strela SA9,[initiator]={[id_]=16834305,},[IniDCSUnitName]=Unit #100,[IniDCSGroup]={[id_]=1130,},[IniDCSUnit]=,[weapon]=,},[3]=Unit #100,[5]=1,})
07666.443 INFO    SCRIPTING: Error in SCHEDULER function:[string "C:\Users\132nd\AppData\Local\Temp\DCS\/~mis00005E67"]:34657: attempt to index field '?' (a nil value)
07666.443 INFO    SCRIPTING: Error in SCHEDULER function:[string "C:\Users\132nd\AppData\Local\Temp\DCS\/~mis00005E67"]:5632: attempt to index global 'debug' (a boolean value)
07666.444 WARNING LOG: 195 duplicate message(s) skipped.
07666.444 INFO    SCRIPTING: Error in SCHEDULER function:[string "C:\Users\132nd\AppData\Local\Temp\DCS\/~mis00005E67"]:5632: C stack overflow
07666.444 INFO    SCRIPTING: Error in SCHEDULER function:[string "C:\Users\132nd\AppData\Local\Temp\DCS\/~mis00005E67"]:5632: attempt to index global 'debug' (a boolean value)```