### PR TITLE
cleanup: remove unreferenced variables

### DIFF
--- a/Moose Development/Moose/AI/AI_A2A.lua
+++ b/Moose Development/Moose/AI/AI_A2A.lua
@@ -367,7 +367,6 @@ end
 -- @return #AI_A2A self
 function AI_A2A:SetFuelThreshold( PatrolFuelThresholdPercentage, PatrolOutOfFuelOrbitTime )
 
-  self.PatrolManageFuel = true
   self.PatrolFuelThresholdPercentage = PatrolFuelThresholdPercentage
   self.PatrolOutOfFuelOrbitTime = PatrolOutOfFuelOrbitTime
   

--- a/Moose Development/Moose/AI/AI_Patrol.lua
+++ b/Moose Development/Moose/AI/AI_Patrol.lua
@@ -590,7 +590,6 @@ end
 -- @return #AI_PATROL_ZONE self
 function AI_PATROL_ZONE:ManageFuel( PatrolFuelThresholdPercentage, PatrolOutOfFuelOrbitTime )
 
-  self.PatrolManageFuel = true
   self.PatrolFuelThresholdPercentage = PatrolFuelThresholdPercentage
   self.PatrolOutOfFuelOrbitTime = PatrolOutOfFuelOrbitTime
   


### PR DESCRIPTION
PatrolManageFuel seems to have been forgotten after a code refactor
in commit ce0be4dcf75d ("Fixing TASK_DISPATCHER and optimizing reports")

$ git rev-parse --show-toplevel
projects/moose
$ pwd
projects/moose
$ git grep "PatrolManageFuel"
Moose Development/Moose/AI/AI_A2A.lua:  self.PatrolManageFuel = true
Moose Development/Moose/AI/AI_Patrol.lua:  self.PatrolManageFuel = true

Signed-off-by: Jonathan Toppins <jtoppins@users.sourceforge.net>