### PR TITLE
Error flag fixed.

### DIFF
--- a/Moose Development/Moose/Wrapper/Client.lua
+++ b/Moose Development/Moose/Wrapper/Client.lua
@@ -74,7 +74,7 @@ CLIENT = {
 --- Finds a CLIENT from the _DATABASE using the relevant DCS Unit.
 -- @param #CLIENT self
 -- @param #string ClientName Name of the DCS **Unit** as defined within the Mission Editor.
--- @param #string ClientBriefing Text that describes the briefing of the mission when a Player logs into the Client.
+-- @param #boolean Error Flag indicating whether or not to throw an error if the CLIENT cannot be found. True by default. Returns `nil` if `Error` is false and no Client was found.
 -- @return #CLIENT
 -- @usage
 -- -- Create new Clients.
@@ -94,7 +94,7 @@ function CLIENT:Find( DCSUnit, Error )
     return ClientFound
   end
   
-  if not Error then
+  if Error or Error == nil then
     error( "CLIENT not found for: " .. ClientName )
   end
 end
@@ -105,7 +105,7 @@ end
 -- @param #CLIENT self
 -- @param #string ClientName Name of the DCS **Unit** as defined within the Mission Editor.
 -- @param #string ClientBriefing Text that describes the briefing of the mission when a Player logs into the Client.
--- @param #boolean Error A flag that indicates whether an error should be raised if the CLIENT cannot be found. By default an error will be raised.
+-- @param #boolean Error Flag indicating whether or not to throw an error if the CLIENT cannot be found. True by default. Returns `nil` if `Error` is false and no Client was found.
 -- @return #CLIENT
 -- @usage
 -- -- Create new Clients.
@@ -127,7 +127,7 @@ function CLIENT:FindByName( ClientName, ClientBriefing, Error )
   	return ClientFound
   end
   
-  if not Error then
+  if Error or Error == nil then
     error( "CLIENT not found for: " .. ClientName )
   end
 end


### PR DESCRIPTION
Fixes #918 

Fixed the misleading language on the `Error` parameter docs. 
Fixed the logic about whether to throw the Error or not, now it's properly inline with the language of the doc.