### PR TITLE
a2a-dispatcher: add check for not in air in OnEventEngineShutdown

### DIFF
--- a/Moose Development/Moose/AI/AI_A2A_Dispatcher.lua
+++ b/Moose Development/Moose/AI/AI_A2A_Dispatcher.lua
@@ -1049,7 +1049,8 @@ do -- AI_A2A_DISPATCHER
     if Squadron then
       self:F( { SquadronName = Squadron.Name } )
       local LandingMethod = self:GetSquadronLanding( Squadron.Name )
-      if LandingMethod == AI_A2A_DISPATCHER.Landing.AtEngineShutdown then
+      if LandingMethod == AI_A2A_DISPATCHER.Landing.AtEngineShutdown and
+        not DefenderUnit:InAir() then
         local DefenderSize = Defender:GetSize()
         if DefenderSize == 1 then
           self:RemoveDefenderFromSquadron( Squadron, Defender )


### PR DESCRIPTION
This fixes the problem of planes owned by gcicap would immediately
despawn when shot causing their engine to quit.

While not ultimately satisfying as planes shot while taxiing will still
immediately despawn. One is now able to see their air victories in all
their glory, including the fiery crash into the ground.

Bug: #932 
Signed-off-by: Jonathan Toppins <jtoppins@users.sourceforge.net>