### PR TITLE
a2a-dispatcher: remove fuel check in OnEventLand() handler

### DIFF
--- a/Moose Development/Moose/AI/AI_A2A_Dispatcher.lua
+++ b/Moose Development/Moose/AI/AI_A2A_Dispatcher.lua
@@ -1033,10 +1033,6 @@ do -- AI_A2A_DISPATCHER
         DefenderUnit:Destroy()
         return
       end
-      if DefenderUnit:GetFuel() <= self.DefenderDefault.FuelThreshold then
-        DefenderUnit:Destroy()
-        return
-      end
     end 
   end
   


### PR DESCRIPTION
This effectivally reverts the change made in commit
ea96a5e0a38b ("Planes remaining at airfield fixed") to declutter
airbases of aircraft which land at incorrect bases.

The problem with the logic is an RTB command will not be issued until
the fuel threshold is reached. Therefore the check will always be true
resulting the the unit always being deleted.

Bug: #875 
Signed-off-by: Jonathan Toppins <jtoppins@users.sourceforge.net>