### PR TITLE
Fixes for ARTY and DESIGNATE classes

### DIFF
--- a/Moose Development/Moose/Core/Set.lua
+++ b/Moose Development/Moose/Core/Set.lua
@@ -865,7 +865,6 @@ function SET_GROUP:FindNearestGroupFromPointVec2( PointVec2 )
   for ObjectID, ObjectData in pairs( self.Set ) do
     if NearestGroup == nil then
       NearestGroup = ObjectData 
-      NearestGroup:GetVec2()
       ClosestDistance = PointVec2:DistanceFromPointVec2( ObjectData:GetCoordinate() )
     else
       local Distance = PointVec2:DistanceFromPointVec2( ObjectData:GetCoordinate() )

--- a/Moose Development/Moose/Core/Set.lua
+++ b/Moose Development/Moose/Core/Set.lua
@@ -859,15 +859,16 @@ end
 function SET_GROUP:FindNearestGroupFromPointVec2( PointVec2 )
   self:F2( PointVec2 )
   
-  local NearestGroup = nil
+  local NearestGroup = nil --Wrapper.Group#GROUP
   local ClosestDistance = nil
   
   for ObjectID, ObjectData in pairs( self.Set ) do
     if NearestGroup == nil then
-      NearestGroup = ObjectData
-      ClosestDistance = PointVec2:DistanceFromVec2( ObjectData:GetVec2() )
+      NearestGroup = ObjectData 
+      NearestGroup:GetVec2()
+      ClosestDistance = PointVec2:DistanceFromPointVec2( ObjectData:GetCoordinate() )
     else
-      local Distance = PointVec2:DistanceFromVec2( ObjectData:GetVec2() )
+      local Distance = PointVec2:DistanceFromPointVec2( ObjectData:GetCoordinate() )
       if Distance < ClosestDistance then
         NearestGroup = ObjectData
         ClosestDistance = Distance

--- a/Moose Development/Moose/Functional/Artillery.lua
+++ b/Moose Development/Moose/Functional/Artillery.lua
@@ -1632,7 +1632,7 @@ function ARTY:onafterStart(Controllable, From, Event, To)
     self.RearmingPlaceCoord=nil
     self.relocateafterfire=false
     self.autorelocate=false
-    self.RearmingGroupSpeed=20
+    --self.RearmingGroupSpeed=20
   end
   
   -- Check that default speed is below max speed.


### PR DESCRIPTION
ARTY:
* Rearming group will not always use 20 km/h = 11 mph.

SET_GROUP (+DESIGNATE):
* Fixed bug in SET_GROUP:FindNearestGroupFromPointVec2( PointVec2 ) function. This caused DESIGNATE class to crash <== critical bug in DESIGNATE!