### PR TITLE
Controllable SetTask debug output

### DIFF
--- a/Moose Development/Moose/Core/Spawn.lua
+++ b/Moose Development/Moose/Core/Spawn.lua
@@ -2639,7 +2639,7 @@ function SPAWN:_OnEngineShutDown( EventData )
   				self:T( { "EngineShutDown: ", "ReSpawn:", SpawnGroup:GetName(), SpawnGroupIndex } )
   				--self:ReSpawn( SpawnGroupIndex )
   				-- Delay respawn by three seconds due to DCS 2.5.4 OB bug https://github.com/FlightControl-Master/MOOSE/issues/1076
-  				SCHEDULER:New(self, self.ReSpawn, {SpawnGroupIndex}, 3)
+  				SCHEDULER:New(nil, self.ReSpawn, {self, SpawnGroupIndex}, 3)
   			end
   		end
     end

--- a/Moose Development/Moose/Ops/Airboss.lua
+++ b/Moose Development/Moose/Ops/Airboss.lua
@@ -278,6 +278,7 @@
 --    * **F3 Request Marshal**
 --    * **F4 Request Commence**
 --    * **F5 Request Refueling**
+--    * **F6 [Reset My Status]**
 -- 
 -- ### Request Marshal
 -- 
@@ -380,12 +381,12 @@
 -- 
 -- ## LSO Grading
 -- 
--- LSO grading starts when the player enters the groove. The flight path and aircraft attitude is evaluated at certain steps
+-- LSO grading starts when the player enters the groove. The flight path and aircraft attitude is evaluated at certain steps (distances measured from rundown):
 -- 
---    * **X** At the Start (0.75 NM = 1389 m from the rundown).
---    * **IM** In the Middle (0.375 NM = 695 from the rundown).
---    * **IC** In Close (0.18 NM = 333 m from the rundown).
---    * **AR** At the Ramp (0.027 NM = 50 m from the rundown).
+--    * **X** At the Start (0.75 NM = 1390 m).
+--    * **IM** In the Middle (0.375 NM = 695 m).
+--    * **IC** In Close (0.18 NM = 333 m).
+--    * **AR** At the Ramp (0.027 NM = 50 m).
 --    * **IW** In the Wiress (at the landing position).
 -- 
 -- Grading at each step includes the above calls, i.e.
@@ -393,7 +394,7 @@
 --    * **L**ined **U**p **L**eft or **R**ight: LUL, LUR
 --    * Too **H**igh or too **LO**w: H, LO
 --    * Too **F**ast or too **SLO**w: F, SLO
---    * Fly through **down* or **up**: \\, /
+--    * **Fly through** glide slope **down** or **up**: \\ , /
 --    
 -- Each grading, x, is subdivided by
 -- 
@@ -408,7 +409,7 @@
 --    * Glide slope error < -1.2 degrees or > 1.8 degrees and/or
 --    * AOA depending on aircraft type and only applied if skill level is "TOPGUN graduate".
 --    
--- Line up and glide slope error thresholds were tested using [https://forums.eagle.ru/showthread.php?t=211557](VFA-113 Stingers LSO Mod),
+-- Line up and glide slope error thresholds were tested using [VFA-113 Stingers LSO Mod](https://forums.eagle.ru/showthread.php?t=211557),
 -- if the aircraft is outside the red box.
 -- 
 -- ## Pattern Wave Off

--- a/Moose Development/Moose/Wrapper/Controllable.lua
+++ b/Moose Development/Moose/Wrapper/Controllable.lua
@@ -381,7 +381,7 @@ end
 -- @param #number WaitTime Time in seconds, before the task is set.
 -- @return Wrapper.Controllable#CONTROLLABLE self
 function CONTROLLABLE:SetTask( DCSTask, WaitTime )
-  self:E( { "SetTask", WaitTime, DCSTask = DCSTask } )
+  self:F( { "SetTask", WaitTime, DCSTask = DCSTask } )
 
   local DCSControllable = self:GetDCSObject()
 
@@ -389,7 +389,7 @@ function CONTROLLABLE:SetTask( DCSTask, WaitTime )
 
     local DCSControllableName = self:GetName()
     
-    self:E( "Controllable Name = " .. DCSControllableName )
+    self:T2( "Controllable Name = " .. DCSControllableName )
 
     -- When a controllable SPAWNs, it takes about a second to get the controllable in the simulator. Setting tasks to unspawned controllables provides unexpected results.
     -- Therefore we schedule the functions to set the mission and options for the Controllable.


### PR DESCRIPTION
Controllable, changed self:E to self:F/T2 since it was spamming the DCS log.
Airboss docs.
Spawn scheduler(self,...) --> scheduler(nil,...)