### PR TITLE
AIRBOSS v0.9.0 and other fixes/improvements

### DIFF
--- a/Moose Development/Moose/Core/Spawn.lua
+++ b/Moose Development/Moose/Core/Spawn.lua
@@ -8,7 +8,7 @@
 --   * Schedule spawning of new groups.
 --   * Put limits on the amount of groups that can be spawned, and the amount of units that can be alive at the same time.
 --   * Randomize the spawning location between different zones.
---   * Randomize the intial positions within the zones.
+--   * Randomize the initial positions within the zones.
 --   * Spawn in array formation.
 --   * Spawn uncontrolled (for planes or helos only).
 --   * Clean up inactive helicopters that "crashed".
@@ -2672,7 +2672,10 @@ function SPAWN:_OnLand( EventData )
   			if self.RepeatOnLanding then
   				local SpawnGroupIndex = self:GetSpawnIndexFromGroup( SpawnGroup )
   				self:T( { "Landed:", "ReSpawn:", SpawnGroup:GetName(), SpawnGroupIndex } )
-  				self:ReSpawn( SpawnGroupIndex )
+  				--self:ReSpawn( SpawnGroupIndex )
+  				-- Delay respawn by three seconds due to DCS 2.5.4.26368 OB bug https://github.com/FlightControl-Master/MOOSE/issues/1076
+  				-- Bug was initially only for engine shutdown event but after ED "fixed" it, it now happens on landing events.
+  				SCHEDULER:New(nil, self.ReSpawn, {self, SpawnGroupIndex}, 3)
   			end
   		end
     end

--- a/Moose Development/Moose/Functional/RAT.lua
+++ b/Moose Development/Moose/Functional/RAT.lua
@@ -546,7 +546,7 @@ RAT.id="RAT | "
 --- RAT version.
 -- @list version
 RAT.version={
-  version = "2.3.4",
+  version = "2.3.5",
   print = true,
 }
 
@@ -2446,7 +2446,7 @@ function RAT:_SetRoute(takeoff, landing, _departure, _destination, _waypoint)
   local VxCruiseMax
   if self.Vcruisemax then
     -- User input.
-    VxCruiseMax = min(self.Vcruisemax, self.aircraft.Vmax)
+    VxCruiseMax = math.min(self.Vcruisemax, self.aircraft.Vmax)
   else
     -- Max cruise speed 90% of Vmax or 900 km/h whichever is lower.
     VxCruiseMax = math.min(self.aircraft.Vmax*0.90, 250)

--- a/Moose Development/Moose/Wrapper/Positionable.lua
+++ b/Moose Development/Moose/Wrapper/Positionable.lua
@@ -4,7 +4,7 @@
 -- 
 -- ### Author: **FlightControl**
 -- 
--- ### Contributions: 
+-- ### Contributions: **Hardcard**, **funkyfranky**
 -- 
 -- ===
 -- 
@@ -310,6 +310,44 @@ function POSITIONABLE:GetCoordinate()
   return nil
 end
 
+--- Returns a COORDINATE object, which is offset with respect to the orientation of the POSITIONABLE.
+-- @param Wrapper.Positionable#POSITIONABLE self
+-- @param #number x Offset in the direction "the nose" of the unit is pointing in meters. Default 0 m.
+-- @param #number y Offset "above" the unit in meters. Default 0 m.
+-- @param #number z Offset in the direction "the wing" of the unit is pointing in meters. z>0 starboard, z<0 port. Default 0 m.
+-- @return Core.Point#COORDINATE The COORDINATE of the offset with respect to the orientation of the  POSITIONABLE.
+function POSITIONABLE:GetOffsetCoordinate(x,y,z)
+  
+  -- Default if nil.
+  x=x or 0
+  y=y or 0
+  z=z or 0
+
+  -- Vectors making up the coordinate system.
+  local X=self:GetOrientationX()
+  local Y=self:GetOrientationY()
+  local Z=self:GetOrientationZ()
+  
+  -- Offset vector: x meters ahead, z meters starboard, y meters above.
+  local A={x=x, y=y, z=z}
+  
+  -- Scale components of orthonormal coordinate vectors.
+  local x={x=X.x*A.x, y=X.y*A.x, z=X.z*A.x}
+  local y={x=Y.x*A.y, y=Y.y*A.y, z=Y.z*A.y}
+  local z={x=Z.x*A.z, y=Z.y*A.z, z=Z.z*A.z}
+  
+  -- Add up vectors in the unit coordinate system ==> this gives the offset vector relative the the origin of the map.
+  local a={x=x.x+y.x+z.x, y=x.y+y.y+z.y, z=x.z+y.z+z.z}
+  
+  -- Vector from the origin of the map to the unit.
+  local u=self:GetVec3()
+  
+  -- Translate offset vector from map origin to the unit: v=u+a.
+  local v={x=a.x+u.x, y=a.y+u.y, z=a.z+u.z}
+  
+  -- Return the offset coordinate.
+  return COORDINATE:NewFromVec3(v)
+end
 
 --- Returns a random @{DCS#Vec3} vector within a range, indicating the point in 3D of the POSITIONABLE within the mission.
 -- @param Wrapper.Positionable#POSITIONABLE self

--- a/Moose Development/Moose/Wrapper/Unit.lua
+++ b/Moose Development/Moose/Wrapper/Unit.lua
@@ -783,6 +783,27 @@ function UNIT:GetThreatLevel()
 
 end
 
+--- Triggers an explosion at the coordinates of the unit.
+-- @param #UNIT self
+-- @param #number power Power of the explosion in kg TNT. Default 100 kg TNT.
+-- @param #number delay (Optional) Delay of explosion in seconds.
+-- @return #UNIT self
+function UNIT:Explode(power, delay)
+
+  -- Default.
+  power=power or 100
+  
+  -- Check if delay or not.
+  if delay and delay>0 then
+    -- Delayed call.
+    SCHEDULER:New(nil, self.Explode, {self, power}, delay)
+  else
+    -- Create an explotion at the coordinate of the unit.
+    self:GetCoordinate():Explosion(power)
+  end
+
+  return self
+end
 
 -- Is functions
 


### PR DESCRIPTION
**AIRBOSS v0.9.0**
- Improved and fixed section handling (still WIP)
- Limited number of Case I Marshal stacks.
- Added Waiting queue for flights waiting on a Case I stack outside 10 NM radius.
- Allowed multiple human flights (default 2) per Marshal stack.
- Added API function to set Case I Marshal radius.
- Added API function that Airboss is a nice guy or not.
- Added API functions to delete Recovery windows.
- Added (static) weather information (cloud layer, visibility range, fog, dust) to weather report.
- Fixed wrong name on Carl Vinson carrier (needs to be all capital).
- Added WAITING step.
- Fixed duration of voice over number 5.
- Added API function for LSO call interval.
- Adjusted default LSO call interval to four seconds.
- Added "RecoverPause" and "RecoveryUnpause" FSM events.
- Added "CheckMissedStep" function if players missed a step in Case II/III.
- Fixed that player only see carriers of their own coalition.
- Added radio message subtitles On/Off to F10 radio menu.
- Fixed typos in docs.
- Lots of other changes under the hood.

**SPAWN**
- Added delay for respawn on landing.

**RAT v2.3.5**
- Fixed bug for Vmax cruise.

**RECOVERYTANKER v1.0.3**
- Added alive check and respawn if not alive.
- Corrected typos in docs.

**RESCUEHELO v1.0.2**
- Added respawn delay. Workaround for DCS bug (hopefully).
- Added alias for multiple helos per carrier.
- Corrected typos in docs.

**POSITIONABLE**
- Added GetOffsetCoordinate function by Hardcard.

**UNIT**
- Added Explode function.