### PR TITLE
Functional atc ground alert freq custom persian gulf

### DIFF
--- a/Moose Development/Moose/Functional/ATC_Ground.lua
+++ b/Moose Development/Moose/Functional/ATC_Ground.lua
@@ -125,6 +125,7 @@ end
 --   Atc_Ground = ATC_GROUND_CAUCAUS:New()
 --   Atc_Ground = ATC_GROUND_NEVADA:New()
 --   Atc_Ground = ATC_GROUND_NORMANDY:New()
+--   Atc_Ground = ATC_GROUND_PERSIANGULF:New()
 --   
 --   -- Then use one of these methods...
 -- 
@@ -190,6 +191,7 @@ end
 --   Atc_Ground = ATC_GROUND_CAUCAUS:New()
 --   Atc_Ground = ATC_GROUND_NEVADA:New()
 --   Atc_Ground = ATC_GROUND_NORMANDY:New()
+--   Atc_Ground = ATC_GROUND_PERSIANGULF:New()
 --   
 --   -- Then use one of these methods...
 -- 
@@ -1557,7 +1559,7 @@ end
 -- 
 -- ---
 -- 
--- The default maximum speed for the airbases at Caucasus is **40 km/h**. Warnings are given if this speed limit is trespassed.
+-- The default maximum speed for the airbases at Normandy is **40 km/h**. Warnings are given if this speed limit is trespassed.
 -- Players will be immediately kicked when driving faster than **100 km/h** on the taxi way.
 -- 
 -- The ATC\_GROUND\_NORMANDY class monitors the speed of the airplanes at the airbase during taxi.
@@ -2315,7 +2317,842 @@ function ATC_GROUND_NORMANDY:New( AirbaseNames )
   return self
 end
 
-     
+
+--- @type ATC_GROUND_PERSIANGULF
+-- @extends #ATC_GROUND
+
+
+--- # ATC\_GROUND\_PERSIANGULF, extends @{#ATC_GROUND}
+-- 
+-- The ATC\_GROUND\_PERSIANGULF class monitors the speed of the airplanes at the airbase during taxi.
+-- The pilots may not drive faster than the maximum speed for the airbase, or they will be despawned.
+-- 
+-- ---
+-- 
+-- ![Banner Image](..\Presentations\ATC_GROUND\Dia1.JPG)
+-- 
+-- ---
+-- 
+-- The default maximum speed for the airbases at Persian Gulf is **50 km/h**. Warnings are given if this speed limit is trespassed.
+-- Players will be immediately kicked when driving faster than **150 km/h** on the taxi way.
+-- 
+-- The ATC\_GROUND\_PERSIANGULF class monitors the speed of the airplanes at the airbase during taxi.
+-- The pilots may not drive faster than the maximum speed for the airbase, or they will be despawned.
+-- 
+-- The pilot will receive 3 times a warning during speeding. After the 3rd warning, if the pilot is still driving
+-- faster than the maximum allowed speed, the pilot will be kicked.
+-- 
+-- Different airbases have different maximum speeds, according safety regulations.
+-- 
+-- # Airbases monitored
+-- 
+-- The following airbases are monitored at the PersianGulf region.
+-- Use the @{Wrapper.Airbase#AIRBASE.PersianGulf} enumeration to select the airbases to be monitored.
+-- 
+--   * `AIRBASE.PersianGulf.Abu_Musa_Island_Airport`
+--   * `AIRBASE.PersianGulf.Al_Dhafra_AB`
+--   * `AIRBASE.PersianGulf.Al_Maktoum_Intl`
+--   * `AIRBASE.PersianGulf.Al_Minhad_AB`
+--   * `AIRBASE.PersianGulf.Bandar_Abbas_Intl`
+--   * `AIRBASE.PersianGulf.Bandar_Lengeh`
+--   * `AIRBASE.PersianGulf.Dubai_Intl`
+--   * `AIRBASE.PersianGulf.Fujairah_Intl`
+--   * `AIRBASE.PersianGulf.Havadarya`
+--   * `AIRBASE.PersianGulf.Kerman_Airport`
+--   * `AIRBASE.PersianGulf.Khasab`
+--   * `AIRBASE.PersianGulf.Lar_Airbase`
+--   * `AIRBASE.PersianGulf.Qeshm_Island`
+--   * `AIRBASE.PersianGulf.Sharjah_Intl`
+--   * `AIRBASE.PersianGulf.Shiraz_International_Airport`
+--   * `AIRBASE.PersianGulf.Sir_Abu_Nuayr`
+--   * `AIRBASE.PersianGulf.Sirri_Island`
+--   * `AIRBASE.PersianGulf.Tunb_Island_AFB`
+--   * `AIRBASE.PersianGulf.Tunb_Kochak`
+--   * `AIRBASE.PersianGulf.Sas_Al_Nakheel_Airport`
+--   * `AIRBASE.PersianGulf.Bandar_e_Jask_airfield`
+--   * `AIRBASE.PersianGulf.Abu_Dhabi_International_Airport`
+--   * `AIRBASE.PersianGulf.Al_Bateen_Airport`
+--   * `AIRBASE.PersianGulf.Kish_International_Airport`
+--   * `AIRBASE.PersianGulf.Al_Ain_International_Airport`
+--   * `AIRBASE.PersianGulf.Lavan_Island_Airport`
+--   * `AIRBASE.PersianGulf.Jiroft_Airport`
+--
+-- # Installation
+-- 
+-- ## In Single Player Missions
+-- 
+-- ATC\_GROUND is fully functional in single player.
+-- 
+-- ## In Multi Player Missions
+-- 
+-- ATC\_GROUND is functional in multi player, however ...
+-- 
+-- Due to a bug in DCS since release 1.5, the despawning of clients are not anymore working in multi player.
+-- To **work around this problem**, a much better solution has been made, using the **slot blocker** script designed
+-- by Ciribob. 
+-- 
+-- With the help of __Ciribob__, this script has been extended to also kick client players while in flight.
+-- ATC\_GROUND is communicating with this modified script to kick players!
+-- 
+-- Install the file **SimpleSlotBlockGameGUI.lua** on the server, following the installation instructions described by Ciribob.
+-- 
+-- [Simple Slot Blocker from Ciribob & FlightControl](https://github.com/ciribob/DCS-SimpleSlotBlock)
+-- 
+-- # Script it!
+-- 
+-- ## 1. ATC_GROUND_PERSIANGULF Constructor
+-- 
+-- Creates a new ATC_GROUND_PERSIANGULF object that will monitor pilots taxiing behaviour.
+-- 
+--     -- This creates a new ATC_GROUND_PERSIANGULF object.
+-- 
+--     -- Monitor for these clients the airbases.
+--     AirbasePoliceCaucasus = ATC_GROUND_PERSIANGULF:New()
+--     
+--     ATC_Ground = ATC_GROUND_PERSIANGULF:New( 
+--       { AIRBASE.PersianGulf.Kerman_Airport,
+--         AIRBASE.PersianGulf.Al_Minhad_AB 
+--       } 
+--     )
+-- 
+--     
+-- ## 2. Set various options
+-- 
+-- There are various methods that you can use to tweak the behaviour of the ATC\_GROUND classes.
+-- 
+-- ### 2.1 Speed limit at an airbase.
+-- 
+--   * @{#ATC_GROUND.SetKickSpeed}(): Set the speed limit allowed at an airbase in meters per second.
+--   * @{#ATC_GROUND.SetKickSpeedKmph}(): Set the speed limit allowed at an airbase in kilometers per hour.
+--   * @{#ATC_GROUND.SetKickSpeedMiph}(): Set the speed limit allowed at an airbase in miles per hour.
+--   
+-- ### 2.2 Prevent Takeoff at an airbase. Players will be kicked immediately.
+-- 
+--   * @{#ATC_GROUND.SetMaximumKickSpeed}(): Set the maximum speed allowed at an airbase in meters per second. 
+--   * @{#ATC_GROUND.SetMaximumKickSpeedKmph}(): Set the maximum speed allowed at an airbase in kilometers per hour.
+--   * @{#ATC_GROUND.SetMaximumKickSpeedMiph}(): Set the maximum speed allowed at an airbase in miles per hour.
+--   
+-- @field #ATC_GROUND_PERSIANGULF
+ATC_GROUND_PERSIANGULF = {
+  ClassName = "ATC_GROUND_PERSIANGULF",
+  Airbases = {
+    [AIRBASE.PersianGulf.Abu_Musa_Island_Airport] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-122813.71002344,["x"]=-31689.936027827,},
+          [2]={["y"]=-122827.82488722,["x"]=-31590.105445836,},
+          [3]={["y"]=-122769.5689949,["x"]=-31583.176330891,},
+          [4]={["y"]=-122726.96776968,["x"]=-31614.998932862,},
+          [5]={["y"]=-121293.92414543,["x"]=-31467.947715689,},
+          [6]={["y"]=-121296.4904843,["x"]=-31432.018971528,},
+          [7]={["y"]=-121236.18152088,["x"]=-31424.576588809,},
+          [8]={["y"]=-121190.50068902,["x"]=-31458.452261875,},
+          [9]={["y"]=-119839.83654246,["x"]=-31319.356695194,},
+          [10]={["y"]=-119824.69514313,["x"]=-31423.293419374,},
+          [11]={["y"]=-119886.80054375,["x"]=-31430.22253432,},
+          [12]={["y"]=-119932.22474173,["x"]=-31395.320325706,},
+          [13]={["y"]=-122813.9472789,["x"]=-31689.81193251,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Abu_Musa_Island_Airport] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-174672.06004916,["x"]=-209880.97145616,},
+          [2]={["y"]=-174705.15693282,["x"]=-209923.15131918,},
+          [3]={["y"]=-171819.05380065,["x"]=-212172.84298281,},
+          [4]={["y"]=-171785.09826475,["x"]=-212129.87417284,},
+          [5]={["y"]=-174671.96413454,["x"]=-209880.52453983,},
+        },
+      [2] = {
+          [1]={["y"]=-174351.95872272,["x"]=-211813.88516693,},
+          [2]={["y"]=-174381.29169939,["x"]=-211851.81242636,},
+          [3]={["y"]=-171493.65648904,["x"]=-214102.92235002,},
+          [4]={["y"]=-171464.99693831,["x"]=-214062.78788361,},
+          [5]={["y"]=-174351.8628081,["x"]=-211813.4382506,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Al_Maktoum_Intl] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-111879.49046471,["x"]=-138953.80105841,},
+          [2]={["y"]=-111917.23447224,["x"]=-139018.2804046,},
+          [3]={["y"]=-108092.98121312,["x"]=-141406.67838426,},
+          [4]={["y"]=-108052.34416748,["x"]=-141341.82058294,},
+          [5]={["y"]=-111879.5412879,["x"]=-138952.87693763,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Al_Minhad_AB] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-91070.628933035,["x"]=-125989.64095162,},
+          [2]={["y"]=-91072.346560159,["x"]=-126040.59722299,},
+          [3]={["y"]=-87098.282779771,["x"]=-126039.41747017,},
+          [4]={["y"]=-87099.632735396,["x"]=-125991.26905291,},
+          [5]={["y"]=-91071.031270042,["x"]=-125987.44617225,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Bandar_Abbas_Intl] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=12988.484058788,["x"]=113979.99250505,},
+          [2]={["y"]=13037.8836239,["x"]=113952.60241152,},
+          [3]={["y"]=14877.313199902,["x"]=117414.37833333,},
+          [4]={["y"]=14828.777486364,["x"]=117439.06043783,},
+          [5]={["y"]=12988.939584604,["x"]=113979.52494386,},
+        },
+        [2] = {
+          [1]={["y"]=13203.406014284,["x"]=113848.44907555,},
+          [2]={["y"]=13258.268500181,["x"]=113818.47303925,},
+          [3]={["y"]=15315.015323566,["x"]=117694.27156647,},
+          [4]={["y"]=15264.815746383,["x"]=117725.22168173,},
+          [5]={["y"]=13203.861540099,["x"]=113847.98151436,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Bandar_Lengeh] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-142373.15541415,["x"]=41364.94047809,},
+          [2]={["y"]=-142363.30071107,["x"]=41298.112282592,},
+          [3]={["y"]=-142217.57151662,["x"]=41320.35666061,},
+          [4]={["y"]=-142213.00856728,["x"]=41291.838227254,},
+          [5]={["y"]=-142131.44584788,["x"]=41301.534494595,},
+          [6]={["y"]=-142132.58658522,["x"]=41323.778872613,},
+          [7]={["y"]=-142123.17550221,["x"]=41336.041798956,},
+          [8]={["y"]=-139580.45381288,["x"]=41711.022304533,},
+          [9]={["y"]=-139590.04241918,["x"]=41778.350996659,},
+          [10]={["y"]=-139732.41237808,["x"]=41757.089304408,},
+          [11]={["y"]=-139736.7897853,["x"]=41785.646675372,},
+          [12]={["y"]=-139816.41690726,["x"]=41775.641173137,},
+          [13]={["y"]=-139816.00001133,["x"]=41754.58792885,},
+          [14]={["y"]=-139824.1294819,["x"]=41743.748634761,},
+          [15]={["y"]=-142373.20183966,["x"]=41365.161507021,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Dubai_Intl] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-89693.511670714,["x"]=-100490.47082052,},
+          [2]={["y"]=-89731.488328846,["x"]=-100555.50584758,},
+          [3]={["y"]=-85706.437275049,["x"]=-103076.68123933,},
+          [4]={["y"]=-85669.519216262,["x"]=-103010.44994755,},
+          [5]={["y"]=-89693.036962487,["x"]=-100489.9961123,},
+        },
+        [2] = {
+          [1]={["y"]=-90797.505501889,["x"]=-99344.082465487,},
+          [2]={["y"]=-90835.482160021,["x"]=-99409.11749254,},
+          [3]={["y"]=-87210.216900398,["x"]=-101681.72494832,},
+          [4]={["y"]=-87171.474397253,["x"]=-101619.20256393,},
+          [5]={["y"]=-90797.030793662,["x"]=-99343.607757261,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Fujairah_Intl] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=5808.8716147284,["x"]=-116602.15633995,},
+          [2]={["y"]=5781.9885293892,["x"]=-116666.67574476,},
+          [3]={["y"]=9435.1910907931,["x"]=-118192.91910235,},
+          [4]={["y"]=9459.878635843,["x"]=-118134.40047704,},
+          [5]={["y"]=5808.4078522575,["x"]=-116603.31550719,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Havadarya] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-7565.4887830428,["x"]=109074.13162774,},
+          [2]={["y"]=-7557.8281079193,["x"]=109030.65729641,},
+          [3]={["y"]=-4987.3556518085,["x"]=109524.49147773,},
+          [4]={["y"]=-4996.215358578,["x"]=109566.57508489,},
+          [5]={["y"]=-7565.4936338604,["x"]=109074.32262205,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Kerman_Airport] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=70375.468628778,["x"]=456046.12685302,},
+          [2]={["y"]=70297.050081575,["x"]=456015.1578105,},
+          [3]={["y"]=71814.291673715,["x"]=452165.51037702,},
+          [4]={["y"]=71902.918622452,["x"]=452188.46411914,},
+          [5]={["y"]=70860.465673482,["x"]=454829.89695989,},
+          [6]={["y"]=70862.525255971,["x"]=454892.77675983,},
+          [7]={["y"]=70816.157465062,["x"]=454922.77944807,},
+          [8]={["y"]=70462.749176371,["x"]=455833.38051827,},
+          [9]={["y"]=70483.400377364,["x"]=455901.17880077,},
+          [10]={["y"]=70453.787334431,["x"]=455974.8217628,},
+          [11]={["y"]=70405.860962315,["x"]=455961.57382254,},
+          [12]={["y"]=70374.689338175,["x"]=456046.51649833,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Khasab] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-534.81827307392,["x"]=-1495.070060483,},
+          [2]={["y"]=-434.82912685139,["x"]=-1519.8421462589,},
+          [3]={["y"]=-405.55302547993,["x"]=-1413.0969766429,},
+          [4]={["y"]=-424.92029254105,["x"]=-1352.0675653224,},
+          [5]={["y"]=216.05735069389,["x"]=1206.9187095195,},
+          [6]={["y"]=116.42961315781,["x"]=1229.9576238247,},
+          [7]={["y"]=88.253643635887,["x"]=1123.7918160128,},
+          [8]={["y"]=101.1741158476,["x"]=1042.6886109249,},
+          [9]={["y"]=-535.31436058928,["x"]=-1494.8762081291,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Lar_Airbase] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-183987.5454359,["x"]=169021.72039309,},
+          [2]={["y"]=-183988.41292374,["x"]=168955.27082471,},
+          [3]={["y"]=-180847.92031188,["x"]=168930.46175795,},
+          [4]={["y"]=-180806.58653731,["x"]=168888.39641215,},
+          [5]={["y"]=-180740.37934087,["x"]=168886.56748407,},
+          [6]={["y"]=-180735.62412787,["x"]=168932.65647164,},
+          [7]={["y"]=-180685.14571291,["x"]=168934.11961411,},
+          [8]={["y"]=-180682.5852136,["x"]=169001.78995301,},
+          [9]={["y"]=-183987.48111493,["x"]=169021.35002828,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Qeshm_Island] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-35140.372717152,["x"]=63373.658918509,},
+          [2]={["y"]=-35098.556715749,["x"]=63320.377239302,},
+          [3]={["y"]=-34991.318905699,["x"]=63408.730403557,},
+          [4]={["y"]=-34984.574389344,["x"]=63401.311435566,},
+          [5]={["y"]=-34991.993357335,["x"]=63313.632722947,},
+          [6]={["y"]=-34956.921872287,["x"]=63265.746656824,},
+          [7]={["y"]=-34917.129225791,["x"]=63261.699947011,},
+          [8]={["y"]=-34832.822771349,["x"]=63337.23853019,},
+          [9]={["y"]=-34915.105870884,["x"]=63436.382920614,},
+          [10]={["y"]=-34906.337999622,["x"]=63478.198922017,},
+          [11]={["y"]=-32728.533668488,["x"]=65307.986209216,},
+          [12]={["y"]=-32676.600892552,["x"]=65299.218337954,},
+          [13]={["y"]=-32623.99366498,["x"]=65334.964274638,},
+          [14]={["y"]=-32626.691471522,["x"]=65388.92040548,},
+          [15]={["y"]=-31822.745121968,["x"]=66067.418750826,},
+          [16]={["y"]=-31777.556862387,["x"]=66068.767654097,},
+          [17]={["y"]=-31691.227053039,["x"]=65974.344425122,},
+          [18]={["y"]=-31606.246146962,["x"]=66042.464040311,},
+          [19]={["y"]=-31602.199437148,["x"]=66084.280041714,},
+          [20]={["y"]=-31632.549760747,["x"]=66124.747139846,},
+          [21]={["y"]=-31727.647441358,["x"]=66134.189462744,},
+          [22]={["y"]=-31734.391957713,["x"]=66141.608430735,},
+          [23]={["y"]=-31632.549760747,["x"]=66225.914885176,},
+          [24]={["y"]=-31673.691310515,["x"]=66277.173209477,},
+          [25]={["y"]=-35140.880825624,["x"]=63373.905965825,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Sharjah_Intl] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-71668.808658476,["x"]=-93980.156242153,},
+          [2]={["y"]=-75307.847363315,["x"]=-91617.097584505,},
+          [3]={["y"]=-75280.458023829,["x"]=-91574.709321014,},
+          [4]={["y"]=-72249.697184234,["x"]=-93529.134331507,},
+          [5]={["y"]=-72179.919581256,["x"]=-93526.199759419,},
+          [6]={["y"]=-72138.183444896,["x"]=-93597.933743788,},
+          [7]={["y"]=-71638.654062835,["x"]=-93927.584008321,},
+          [8]={["y"]=-71668.325847279,["x"]=-93979.428115206,},
+        },
+        [2] = {
+          [1]={["y"]=-71553.225408723,["x"]=-93775.312323319,},
+          [2]={["y"]=-75168.13829548,["x"]=-91426.51571111,},
+          [3]={["y"]=-75125.388157445,["x"]=-91363.754870166,},
+          [4]={["y"]=-71510.511081666,["x"]=-93703.252275385,},
+          [5]={["y"]=-71552.247218027,["x"]=-93775.638386885,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Shiraz_International_Airport] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-353995.75579778,["x"]=382327.42294273,},
+          [2]={["y"]=-354029.77009807,["x"]=382265.46199492,},
+          [3]={["y"]=-349407.98049238,["x"]=379941.14030526,},
+          [4]={["y"]=-349376.87025024,["x"]=380004.69408564,},
+          [5]={["y"]=-353995.71101815,["x"]=382327.59771695,},
+        },
+        [2] = {
+          [1]={["y"]=-354056.29510012,["x"]=381845.97598829,},
+          [2]={["y"]=-354091.48797289,["x"]=381783.6025623,},
+          [3]={["y"]=-349650.64038107,["x"]=379550.92898242,},
+          [4]={["y"]=-349624.41889127,["x"]=379614.92719482,},
+          [5]={["y"]=-354056.25032049,["x"]=381846.15076251,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Sir_Abu_Nuayr] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-203367.3128691,["x"]=-103017.22553918,},
+          [2]={["y"]=-203373.59664477,["x"]=-103054.92819323,},
+          [3]={["y"]=-202578.27577922,["x"]=-103188.26018333,},
+          [4]={["y"]=-202571.37254488,["x"]=-103151.01482599,},
+          [5]={["y"]=-203367.65259839,["x"]=-103016.48202662,},
+          [6]={["y"]=-203291.39594004,["x"]=-102985.49774228,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Sirri_Island] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-169713.12842428,["x"]=-27766.658020853,},
+          [2]={["y"]=-169682.02009414,["x"]=-27726.583172021,},
+          [3]={["y"]=-169727.21866794,["x"]=-27691.632048154,},
+          [4]={["y"]=-169694.28043602,["x"]=-27650.276268081,},
+          [5]={["y"]=-169763.08474269,["x"]=-27598.490047901,},
+          [6]={["y"]=-169825.30140298,["x"]=-27607.090586235,},
+          [7]={["y"]=-171614.98889813,["x"]=-26246.247907014,},
+          [8]={["y"]=-171620.85326172,["x"]=-26187.105176343,},
+          [9]={["y"]=-171686.10990337,["x"]=-26138.56820961,},
+          [10]={["y"]=-171716.55468456,["x"]=-26178.745338885,},
+          [11]={["y"]=-171764.9668776,["x"]=-26142.810515186,},
+          [12]={["y"]=-171796.29599657,["x"]=-26183.416460911,},
+          [13]={["y"]=-169713.5628285,["x"]=-27766.883787223,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Tunb_Island_AFB] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-92923.634698863,["x"]=9547.6862547173,},
+          [2]={["y"]=-92963.030803298,["x"]=9565.7274614215,},
+          [3]={["y"]=-92934.128053782,["x"]=9619.2987996964,},
+          [4]={["y"]=-92970.946842975,["x"]=9640.1014155901,},
+          [5]={["y"]=-92949.591945243,["x"]=9682.8112110532,},
+          [6]={["y"]=-92899.518391942,["x"]=9699.7478540817,},
+          [7]={["y"]=-91969.13471408,["x"]=11464.627292768,},
+          [8]={["y"]=-91983.666755417,["x"]=11515.293058512,},
+          [9]={["y"]=-91960.101282978,["x"]=11557.710908902,},
+          [10]={["y"]=-91921.021874517,["x"]=11539.251288825,},
+          [11]={["y"]=-91893.725202275,["x"]=11589.720675632,},
+          [12]={["y"]=-91859.751646175,["x"]=11571.850192366,},
+          [13]={["y"]=-92922.149728329,["x"]=9547.2937058617,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Tunb_Kochak] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-109925.50271188,["x"]=8974.5666013181,},
+          [2]={["y"]=-109905.7382908,["x"]=8937.53274444,},
+          [3]={["y"]=-109009.93726324,["x"]=9072.2234968343,},
+          [4]={["y"]=-109040.82867587,["x"]=9104.9871291834,},
+          [5]={["y"]=-109925.26515172,["x"]=8974.091480998,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Sas_Al_Nakheel_Airport] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-176230.75865538,["x"]=-188732.01369812,},
+          [2]={["y"]=-176274.78045186,["x"]=-188744.8049371,},
+          [3]={["y"]=-175692.03171595,["x"]=-190564.17145168,},
+          [4]={["y"]=-175649.7486572,["x"]=-190550.58435053,},
+          [5]={["y"]=-176230.66274076,["x"]=-188731.5667818,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Bandar_e_Jask_airfield] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=155156.73167657,["x"]=-57837.031277333,},
+          [2]={["y"]=155130.38996239,["x"]=-57790.475605714,},
+          [3]={["y"]=157137.17872571,["x"]=-56710.411783359,},
+          [4]={["y"]=157148.46631801,["x"]=-56688.071756941,},
+          [5]={["y"]=157220.07198163,["x"]=-56649.035500253,},
+          [6]={["y"]=157227.83220133,["x"]=-56662.204357931,},
+          [7]={["y"]=157359.6383572,["x"]=-56590.481115222,},
+          [8]={["y"]=157383.03659539,["x"]=-56633.044744502,},
+          [9]={["y"]=155156.7940421,["x"]=-57837.149989814,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Abu_Dhabi_International_Airport] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-163964.56943899,["x"]=-189427.63621921,},
+          [2]={["y"]=-164005.96838287,["x"]=-189478.90226888,},
+          [3]={["y"]=-160798.22080495,["x"]=-192054.59531727,},
+          [4]={["y"]=-160755.05282258,["x"]=-192002.58569997,},
+          [5]={["y"]=-163964.47352437,["x"]=-189427.18930288,},
+        },
+        [2] = {
+          [1]={["y"]=-163615.44952024,["x"]=-187144.00786922,},
+          [2]={["y"]=-163656.84846411,["x"]=-187195.27391888,},
+          [3]={["y"]=-160452.71811093,["x"]=-189764.86593382,},
+          [4]={["y"]=-160411.94568221,["x"]=-189715.47961171,},
+          [5]={["y"]=-163615.35360562,["x"]=-187143.56095289,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Al_Bateen_Airport] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-183207.51774197,["x"]=-189871.8319832,},
+          [2]={["y"]=-183240.61462564,["x"]=-189914.01184622,},
+          [3]={["y"]=-180748.88998479,["x"]=-191943.30402837,},
+          [4]={["y"]=-180711.83076051,["x"]=-191896.52435182,},
+          [5]={["y"]=-183207.42182735,["x"]=-189871.38506688,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Kish_International_Airport] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-227330.79164594,["x"]=42691.91536494,},
+          [2]={["y"]=-227321.58531968,["x"]=42758.113234714,},
+          [3]={["y"]=-223235.73004619,["x"]=42313.579195302,},
+          [4]={["y"]=-223240.99080406,["x"]=42247.819722016,},
+          [5]={["y"]=-227330.67774245,["x"]=42691.785682556,},
+        },
+        [2] = {
+          [1]={["y"]=-227283.77911886,["x"]=42987.748941936,},
+          [2]={["y"]=-227274.5727926,["x"]=43053.946811711,},
+          [3]={["y"]=-222907.94761294,["x"]=42580.826755904,},
+          [4]={["y"]=-222915.76510871,["x"]=42514.58376547,},
+          [5]={["y"]=-227283.66521537,["x"]=42987.619259553,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Al_Ain_International_Airport] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-65165.315648901,["x"]=-209042.45716363,},
+          [2]={["y"]=-65112.933878375,["x"]=-209048.84518442,},
+          [3]={["y"]=-65672.013626755,["x"]=-213019.66479976,},
+          [4]={["y"]=-65722.555424932,["x"]=-213013.91596964,},
+          [5]={["y"]=-65165.400582791,["x"]=-209042.15059908,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Lavan_Island_Airport] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=-288099.83301495,["x"]=76353.443273049,},
+          [2]={["y"]=-288119.51457685,["x"]=76302.756224611,},
+          [3]={["y"]=-288070.96603401,["x"]=76283.898526152,},
+          [4]={["y"]=-288085.61084238,["x"]=76247.386812114,},
+          [5]={["y"]=-288032.04695421,["x"]=76224.316223573,},
+          [6]={["y"]=-287991.12173627,["x"]=76245.38067398,},
+          [7]={["y"]=-287489.96435675,["x"]=76037.610404141,},
+          [8]={["y"]=-287497.65444594,["x"]=76017.686082159,},
+          [9]={["y"]=-287453.61120787,["x"]=75998.111309685,},
+          [10]={["y"]=-287419.70490555,["x"]=76007.199596905,},
+          [11]={["y"]=-285642.24565503,["x"]=75279.787069797,},
+          [12]={["y"]=-285625.46727862,["x"]=75239.239326815,},
+          [13]={["y"]=-285570.23845628,["x"]=75217.217707782,},
+          [14]={["y"]=-285555.20782742,["x"]=75252.172658628,},
+          [15]={["y"]=-285505.92134673,["x"]=75231.199688121,},
+          [16]={["y"]=-285484.28380792,["x"]=75284.258832895,},
+          [17]={["y"]=-288099.97979219,["x"]=76354.32393647,},
+        },
+      },
+    },
+    [AIRBASE.PersianGulf.Jiroft_Airport] = {
+      PointsRunways = {
+        [1] = {
+          [1]={["y"]=140376.87310595,["x"]=283748.07558774,},
+          [2]={["y"]=140299.43760975,["x"]=283655.81201779,},
+          [3]={["y"]=143008.43807723,["x"]=281517.41347718,},
+          [4]={["y"]=143052.6952428,["x"]=281573.25195709,},
+          [5]={["y"]=142946.60213095,["x"]=281656.5960586,},
+          [6]={["y"]=142975.14179847,["x"]=281687.20381796,},
+          [7]={["y"]=142932.12548801,["x"]=281724.01585287,},
+          [8]={["y"]=142870.49635092,["x"]=281719.05243244,},
+          [9]={["y"]=140437.35783025,["x"]=283640.84253664,},
+          [10]={["y"]=140433.27045062,["x"]=283705.80267729,},
+          [11]={["y"]=140376.77702493,["x"]=283747.8442964,},
+        },
+      },
+    },
+  },
+}
+
+
+--- Creates a new ATC_GROUND_PERSIANGULF object.
+-- @param #ATC_GROUND_PERSIANGULF self
+-- @param AirbaseNames A list {} of airbase names (Use AIRBASE.PersianGulf enumerator).
+-- @return #ATC_GROUND_PERSIANGULF self
+function ATC_GROUND_PERSIANGULF:New( AirbaseNames )
+
+  -- Inherits from BASE
+  local self = BASE:Inherit( self, ATC_GROUND:New( self.Airbases, AirbaseNames ) ) -- #ATC_GROUND_PERSIANGULF
+
+  self.AirbaseMonitor = SCHEDULER:New( self, self._AirbaseMonitor, { self }, 0, 2, 0.05 )
+  
+  self:SetKickSpeedKmph( 50 )
+  self:SetMaximumKickSpeedKmph( 150 )
+
+  -- These lines here are for the demonstration mission.
+  -- They create in the dcs.log the coordinates of the runway polygons, that are then
+  -- taken by the moose designer from the dcs.log and reworked to define the
+  -- Airbases structure, which is part of the class.
+  -- When new airbases are added or airbases are changed on the map,
+  -- the MOOSE designer willde-comment this section and apply the changes in the demo
+  -- mission, and do a re-run to create a new dcs.log, and then add the changed coordinates
+  -- in the Airbases structure.
+  -- So, this needs to stay commented normally once a map has been finished.
+  
+
+  --[[
+  
+  -- Abu_Musa_Island_Airport
+  do
+    local VillagePrefix = "Abu_Musa_Island_Airport" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Al_Dhafra_AB
+  do
+    local VillagePrefix = "Al_Dhafra_AB" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+    local Runway2 = GROUP:FindByName( VillagePrefix .. " 2" )
+    local Zone2 = ZONE_POLYGON:New( VillagePrefix .. " 2", Runway2 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Al_Maktoum_Intl
+  do
+    local VillagePrefix = "Al_Maktoum_Intl" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Al_Minhad_AB
+  do
+    local VillagePrefix = "Al_Minhad_AB" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Bandar_Abbas_Intl
+  do
+    local VillagePrefix = "Bandar_Abbas_Intl" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+    local Runway2 = GROUP:FindByName( VillagePrefix .. " 2" )
+    local Zone2 = ZONE_POLYGON:New( VillagePrefix .. " 2", Runway2 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Bandar_Lengeh
+  do
+    local VillagePrefix = "Bandar_Lengeh" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Dubai_Intl
+  do
+    local VillagePrefix = "Dubai_Intl" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+    local Runway2 = GROUP:FindByName( VillagePrefix .. " 2" )
+    local Zone2 = ZONE_POLYGON:New( VillagePrefix .. " 2", Runway2 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Fujairah_Intl
+  do
+    local VillagePrefix = "Fujairah_Intl" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Havadarya
+  do
+    local VillagePrefix = "Havadarya" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Kerman_Airport
+  do
+    local VillagePrefix = "Kerman_Airport" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Khasab
+  do
+    local VillagePrefix = "Khasab" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Lar_Airbase
+  do
+    local VillagePrefix = "Lar_Airbase" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Qeshm_Island
+  do
+    local VillagePrefix = "Qeshm_Island" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Sharjah_Intl
+  do
+    local VillagePrefix = "Sharjah_Intl" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+    local Runway2 = GROUP:FindByName( VillagePrefix .. " 2" )
+    local Zone2 = ZONE_POLYGON:New( VillagePrefix .. " 2", Runway2 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Shiraz_International_Airport
+  do
+    local VillagePrefix = "Shiraz_International_Airport" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+    local Runway2 = GROUP:FindByName( VillagePrefix .. " 2" )
+    local Zone2 = ZONE_POLYGON:New( VillagePrefix .. " 2", Runway2 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Sir_Abu_Nuayr
+  do
+    local VillagePrefix = "Sir_Abu_Nuayr" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Sirri_Island
+  do
+    local VillagePrefix = "Sirri_Island" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Tunb_Island_AFB
+  do
+    local VillagePrefix = "Tunb_Island_AFB" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Tunb_Kochak
+  do
+    local VillagePrefix = "Tunb_Kochak" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+
+  -- Sas_Al_Nakheel_Airport
+  do
+    local VillagePrefix = "Sas_Al_Nakheel_Airport" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Bandar_e_Jask_airfield
+  do
+    local VillagePrefix = "Bandar_e_Jask_airfield" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Abu_Dhabi_International_Airport
+  do
+    local VillagePrefix = "Abu_Dhabi_International_Airport" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+    local Runway2 = GROUP:FindByName( VillagePrefix .. " 2" )
+    local Zone2 = ZONE_POLYGON:New( VillagePrefix .. " 2", Runway2 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Al_Bateen_Airport
+  do
+    local VillagePrefix = "Al_Bateen_Airport" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Kish_International_Airport
+  do
+    local VillagePrefix = "Kish_International_Airport" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+    local Runway2 = GROUP:FindByName( VillagePrefix .. " 2" )
+    local Zone2 = ZONE_POLYGON:New( VillagePrefix .. " 2", Runway2 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Al_Ain_International_Airport
+  do
+    local VillagePrefix = "Al_Ain_International_Airport" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Lavan_Island_Airport
+  do
+    local VillagePrefix = "Lavan_Island_Airport" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Jiroft_Airport
+  do
+    local VillagePrefix = "Jiroft_Airport" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  
+  -- Bandar_Abbas_Intl
+  do
+    local VillagePrefix = "Bandar_Abbas_Intl" 
+    local Runway1 = GROUP:FindByName( VillagePrefix .. " 1" )
+    local Zone1 = ZONE_POLYGON:New( VillagePrefix .. " 1", Runway1 ):SmokeZone(SMOKECOLOR.Red):Flush()
+    local Runway2 = GROUP:FindByName( VillagePrefix .. " 2" )
+    local Zone2 = ZONE_POLYGON:New( VillagePrefix .. " 2", Runway2 ):SmokeZone(SMOKECOLOR.Red):Flush()
+  end
+  
+  --]]
+  
+  return self
+end
+
+          
 
 
      

--- a/Moose Development/Moose/Functional/ATC_Ground.lua
+++ b/Moose Development/Moose/Functional/ATC_Ground.lua
@@ -275,7 +275,7 @@ function ATC_GROUND:_AirbaseMonitor()
                 self:E( Taxi )
                 if Taxi == false then
                   local Velocity = VELOCITY:New( AirbaseMeta.KickSpeed or self.KickSpeed )
-                  Client:Message( "Welcome at " .. AirbaseID .. ". The maximum taxiing speed is " .. 
+                  Client:Message( "Welcome to " .. AirbaseID .. ". The maximum taxiing speed is " .. 
                                   Velocity:ToString() , 20, "ATC" )
                   Client:SetState( self, "Taxi", true )
                 end
@@ -299,7 +299,7 @@ function ATC_GROUND:_AirbaseMonitor()
                   end
                   if Speeding == true then
                     MESSAGE:New( "Penalty! Player " .. Client:GetPlayerName() .. 
-                                 " is kicked, due to a severe airbase traffic rule violation ...", 10, "ATC" ):ToAll()
+                                 " has been kicked, due to a severe airbase traffic rule violation ...", 10, "ATC" ):ToAll()
                     Client:Destroy()
                     Client:SetState( self, "Speeding", false )
                     Client:SetState( self, "Warnings", 0 )
@@ -331,7 +331,7 @@ function ATC_GROUND:_AirbaseMonitor()
                                         Velocity:ToString(), 5, "ATC" )
                         Client:SetState( self, "Warnings", SpeedingWarnings + 1 )
                       else
-                        MESSAGE:New( "Penalty! Player " .. Client:GetPlayerName() .. " is kicked, due to a severe airbase traffic rule violation ...", 10, "ATC" ):ToAll()
+                        MESSAGE:New( "Penalty! Player " .. Client:GetPlayerName() .. " has been kicked, due to a severe airbase traffic rule violation ...", 10, "ATC" ):ToAll()
                         --- @param Wrapper.Client#CLIENT Client
                         Client:Destroy()
                         Client:SetState( self, "Speeding", false )
@@ -363,7 +363,7 @@ function ATC_GROUND:_AirbaseMonitor()
                       Client:Message( "Warning " .. OffRunwayWarnings .. "/3! Airbase traffic rule violation! Get back on the taxi immediately!", 5, "ATC" )
                       Client:SetState( self, "OffRunwayWarnings", OffRunwayWarnings + 1 )
                     else
-                      MESSAGE:New( "Penalty! Player " .. Client:GetPlayerName() .. " is kicked, due to a severe airbase traffic rule violation ...", 10, "ATC" ):ToAll()
+                      MESSAGE:New( "Penalty! Player " .. Client:GetPlayerName() .. " has been kicked, due to a severe airbase traffic rule violation ...", 10, "ATC" ):ToAll()
                       --- @param Wrapper.Client#CLIENT Client
                       Client:Destroy()
                       Client:SetState( self, "IsOffRunway", false )
@@ -788,8 +788,6 @@ function ATC_GROUND_CAUCASUS:New( AirbaseNames )
   -- Inherits from BASE
   local self = BASE:Inherit( self, ATC_GROUND:New( self.Airbases, AirbaseNames ) )
 
-  self.AirbaseMonitor = SCHEDULER:New( self, self._AirbaseMonitor, { self }, 0, 2, 0.05 )
-
   self:SetKickSpeedKmph( 50 )
   self:SetMaximumKickSpeedKmph( 150 )
 
@@ -1001,6 +999,15 @@ function ATC_GROUND_CAUCASUS:New( AirbaseNames )
   return self
 end
 
+
+--- Start SCHEDULER for ATC_GROUND_CAUCASUS object.
+-- @param #ATC_GROUND_CAUCASUS self
+-- @param RepeatScanSeconds Time in second for defining occurency of alerts.
+-- @return nothing
+function ATC_GROUND_CAUCASUS:Start( RepeatScanSeconds )
+  RepeatScanSeconds = RepeatScanSeconds or 0.05
+  self.AirbaseMonitor = SCHEDULER:New( self, self._AirbaseMonitor, { self }, 0, 2, RepeatScanSeconds )
+end
 
 
 
@@ -1379,8 +1386,6 @@ function ATC_GROUND_NEVADA:New( AirbaseNames )
   -- Inherits from BASE
   local self = BASE:Inherit( self, ATC_GROUND:New( self.Airbases, AirbaseNames ) )
 
-  self.AirbaseMonitor = SCHEDULER:New( self, self._AirbaseMonitor, { self }, 0, 2, 0.05 )
-
   self:SetKickSpeedKmph( 50 )
   self:SetMaximumKickSpeedKmph( 150 )
 
@@ -1543,6 +1548,16 @@ function ATC_GROUND_NEVADA:New( AirbaseNames )
   
   return self
 end
+
+--- Start SCHEDULER for ATC_GROUND_NEVADA object.
+-- @param #ATC_GROUND_NEVADA self
+-- @param RepeatScanSeconds Time in second for defining occurency of alerts.
+-- @return nothing
+function ATC_GROUND_NEVADA:Start( RepeatScanSeconds )
+  RepeatScanSeconds = RepeatScanSeconds or 0.05
+  self.AirbaseMonitor = SCHEDULER:New( self, self._AirbaseMonitor, { self }, 0, 2, RepeatScanSeconds )
+end
+
 
 --- @type ATC_GROUND_NORMANDY
 -- @extends #ATC_GROUND
@@ -2033,8 +2048,6 @@ function ATC_GROUND_NORMANDY:New( AirbaseNames )
 
   -- Inherits from BASE
   local self = BASE:Inherit( self, ATC_GROUND:New( self.Airbases, AirbaseNames ) ) -- #ATC_GROUND_NORMANDY
-
-  self.AirbaseMonitor = SCHEDULER:New( self, self._AirbaseMonitor, { self }, 0, 2, 0.05 )
   
   self:SetKickSpeedKmph( 40 )
   self:SetMaximumKickSpeedKmph( 100 )
@@ -2317,6 +2330,15 @@ function ATC_GROUND_NORMANDY:New( AirbaseNames )
   return self
 end
 
+     
+--- Start SCHEDULER for ATC_GROUND_NORMANDY object.
+-- @param #ATC_GROUND_NORMANDY self
+-- @param RepeatScanSeconds Time in second for defining occurency of alerts.
+-- @return nothing
+function ATC_GROUND_NORMANDY:Start( RepeatScanSeconds )
+  RepeatScanSeconds = RepeatScanSeconds or 0.05
+  self.AirbaseMonitor = SCHEDULER:New( self, self._AirbaseMonitor, { self }, 0, 2, RepeatScanSeconds )
+end
 
 --- @type ATC_GROUND_PERSIANGULF
 -- @extends #ATC_GROUND
@@ -2889,8 +2911,6 @@ function ATC_GROUND_PERSIANGULF:New( AirbaseNames )
 
   -- Inherits from BASE
   local self = BASE:Inherit( self, ATC_GROUND:New( self.Airbases, AirbaseNames ) ) -- #ATC_GROUND_PERSIANGULF
-
-  self.AirbaseMonitor = SCHEDULER:New( self, self._AirbaseMonitor, { self }, 0, 2, 0.05 )
   
   self:SetKickSpeedKmph( 50 )
   self:SetMaximumKickSpeedKmph( 150 )
@@ -3152,6 +3172,14 @@ function ATC_GROUND_PERSIANGULF:New( AirbaseNames )
   return self
 end
 
+--- Start SCHEDULER for ATC_GROUND_PERSIANGULF object.
+-- @param #ATC_GROUND_PERSIANGULF self
+-- @param RepeatScanSeconds Time in second for defining occurency of alerts.
+-- @return nothing
+function ATC_GROUND_PERSIANGULF:Start( RepeatScanSeconds )
+  RepeatScanSeconds = RepeatScanSeconds or 0.05
+  self.AirbaseMonitor = SCHEDULER:New( self, self._AirbaseMonitor, { self }, 0, 2, RepeatScanSeconds )
+end
           
 
 

--- a/Moose Development/Moose/Wrapper/Airbase.lua
+++ b/Moose Development/Moose/Wrapper/Airbase.lua
@@ -238,6 +238,15 @@ AIRBASE.Normandy = {
 -- * AIRBASE.PersianGulf.Sharjah_Intl
 -- * AIRBASE.PersianGulf.Shiraz_International_Airport
 -- * AIRBASE.PersianGulf.Kerman_Airport
+-- * AIRBASE.PersianGulf.Sas_Al_Nakheel_Airport
+-- * AIRBASE.PersianGulf.Bandar_e_Jask_airfield
+-- * AIRBASE.PersianGulf.Abu_Dhabi_International_Airport
+-- * AIRBASE.PersianGulf.Al_Bateen_Airport
+-- * AIRBASE.PersianGulf.Kish_International_Airport
+-- * AIRBASE.PersianGulf.Al_Ain_International_Airport
+-- * AIRBASE.PersianGulf.Lavan_Island_Airport
+-- * AIRBASE.PersianGulf.Jiroft_Airport
+-- 
 -- @field PersianGulf
 AIRBASE.PersianGulf = {
   ["Fujairah_Intl"] = "Fujairah Intl",
@@ -259,6 +268,14 @@ AIRBASE.PersianGulf = {
   ["Sharjah_Intl"] = "Sharjah Intl",
   ["Shiraz_International_Airport"] = "Shiraz International Airport",
   ["Kerman_Airport"] = "Kerman Airport",
+  ["Sas_Al_Nakheel_Airport"] = "Sas Al Nakheel Airport",
+  ["Bandar_e_Jask_airfield"] = "Bandar-e-Jask airfield",
+  ["Abu_Dhabi_International_Airport"] = "Abu Dhabi International Airport",
+  ["Al_Bateen_Airport"] = "Al-Bateen Airport",
+  ["Kish_International_Airport"] = "Kish International Airport",
+  ["Al_Ain_International_Airport"] = "Al Ain International Airport",
+  ["Lavan_Island_Airport"] = "Lavan Island Airport",
+  ["Jiroft_Airport"] = "Jiroft Airport",
   }
   
 --- AIRBASE.ParkingSpot ".Coordinate, ".TerminalID", ".TerminalType", ".TOAC", ".Free", ".TerminalID0", ".DistToRwy".


### PR DESCRIPTION
Set the time frequency of alert with PersianGulf
Add new functions "Start" for
ATC_GROUND_CAUCASUS,
ATC_GROUND_NEVADA,
ATC_GROUND_NORMANDY,
ATC_GROUND_PERSIANGULF

which accept none or one parameter for setting the SCHEDULER frequency.

If none defined, value set before (0.05) is used.
The SCHEDULER is not anymore in "New" functions of ATC_GROUND_XXX but in "Start"

Usages:
atcGroundCaucasus=ATC_GROUND_CAUCASUS:New()
atcGroundCausasus:Start()

or

atcGroundCaucasus=ATC_GROUND_CAUCASUS:New()
atcGroundCausasus:Start(0.5)

Relative to PullRequest #1094, #1096, #1098
Include grammar issues fix from ticket #753 
Test for FunkyFranky