### PR TITLE
Fix 2 bugs inside CommandCenter.lua related to Issues #1090 and #1091

### DIFF
--- a/Moose Development/Moose/Tasking/CommandCenter.lua
+++ b/Moose Development/Moose/Tasking/CommandCenter.lua
@@ -183,7 +183,6 @@ function COMMANDCENTER:New( CommandCenterPositionable, CommandCenterName )
         if EventGroup and self:HasGroup( EventGroup ) then
           local CommandCenterMenu = MENU_GROUP:New( EventGroup, self:GetText() )
           local MenuReporting = MENU_GROUP:New( EventGroup, "Missions Reports", CommandCenterMenu )
-          local MenuMissionsSummary = MENU_GROUP_COMMAND:New( EventGroup, "Missions Status Report", MenuReporting, self.ReportMissionsStatus, self, EventGroup )
           local MenuMissionsDetails = MENU_GROUP_COMMAND:New( EventGroup, "Missions Players Report", MenuReporting, self.ReportMissionsPlayers, self, EventGroup )
           self:ReportSummary( EventGroup )
           local PlayerUnit = EventData.IniUnit
@@ -417,11 +416,6 @@ function COMMANDCENTER:SetMenu()
   for MissionID, Mission in pairs( self:GetMissions() or {} ) do
     local Mission = Mission -- Tasking.Mission#MISSION
     Mission:SetMenu( MenuTime )
-  end
-
-  for MissionID, Mission in pairs( self:GetMissions() or {} ) do
-    Mission = Mission -- Tasking.Mission#MISSION
-    Mission:RemoveMenu( MenuTime )
   end
   
 end


### PR DESCRIPTION
Remove line 186 which adding GroupMenu for Missions Status Report by calling self.ReportMissionsStatus which doesn't exist and generate Nil access in dcs.log when menu call by user.

Remove lines 421, 422, 423 and 424 because they don't have to be there. They removed the Menu just previously added by the function.