### PR TITLE
Fix TaskBombingRunway structure

### DIFF
--- a/Moose Development/Moose/Wrapper/Controllable.lua
+++ b/Moose Development/Moose/Wrapper/Controllable.lua
@@ -933,12 +933,12 @@ function CONTROLLABLE:TaskBombingRunway( Airbase, WeaponType, WeaponExpend, Atta
   local DCSTask
   DCSTask = { id = 'BombingRunway',
     params = {
-    point = Airbase:GetID(),
+    runwayId = Airbase:GetID(),
     weaponType = WeaponType, 
     expend = WeaponExpend,
     attackQty = AttackQty, 
     direction = Direction, 
-    controllableAttack = ControllableAttack, 
+    groupAttack  = ControllableAttack, 
     },
   },
 


### PR DESCRIPTION
The Task structure for TaskBombingRunway wasn't using the right parameters.
According to wiki.hoggitworld.com and #1088 report fields:
- point changed to runwayId
- controllableAttack to groupAttack
https://wiki.hoggitworld.com/view/DCS_task_bombingRunway