### PR TITLE
Adding route name fetch to getGroupRoute()

### DIFF
--- a/Moose Development/Moose/Utilities/Routines.lua
+++ b/Moose Development/Moose/Utilities/Routines.lua
@@ -1631,6 +1631,11 @@ function routines.getGroupRoute(groupIdent, task)   -- same as getGroupPoints bu
 											
 											for point_num, point in pairs(group_data.route.points) do
 												local routeData = {}
+												if env.mission.version > 7 then
+													routeData.name = env.getValueDictByKey(point.name)
+												else
+													routeData.name = point.name
+												end
 												if not point.point then
 													routeData.x = point.x
 													routeData.y = point.y


### PR DESCRIPTION
Adding in fetching of route names so that more specific processing can be accomplished around named WPs. This allows mission designers the ability to produce richer mission content via different methods of processing WPs on a named basis.