### PR TITLE
Issue #1264 Abu_Musa_Island_Airport

### DIFF
--- a/.scannerwork/report-task.txt
+++ b/.scannerwork/report-task.txt
@@ -1,0 +1,6 @@
+projectKey=Test
+serverUrl=http://localhost:9000
+serverVersion=8.1.0.31237
+dashboardUrl=http://localhost:9000/dashboard?id=Test
+ceTaskId=AXAlUJO97YLjwz1VUDXR
+ceTaskUrl=http://localhost:9000/api/ce/task?id=AXAlUJO97YLjwz1VUDXR

--- a/Moose Development/Moose/Functional/ATC_Ground.lua
+++ b/Moose Development/Moose/Functional/ATC_Ground.lua
@@ -2458,7 +2458,7 @@ end
 ATC_GROUND_PERSIANGULF = {
   ClassName = "ATC_GROUND_PERSIANGULF",
   Airbases = {
-    [AIRBASE.PersianGulf.Abu_Musa_Island_Airport] = {
+    [AIRBASE.PersianGulf.Al_Dhafra_AB] = { ---FIX by Wingthor Changed from Abu_Musa_Island_Airport
       PointsRunways = {
         [1] = {
           [1]={["y"]=-122813.71002344,["x"]=-31689.936027827,},


### PR DESCRIPTION
Solves Issue #1264 

Changed Abu_Musa_Island_Airport to Al_Dhafra_AB.

No errors in log, also tested and worked. Noticed script cause a lot of lines in dcs.log, which made no sense.
 
eg: ```
2020-02-11 14:50:27.275 INFO    SCRIPTING:  48510( 13408)/E:        ATC_GROUND_PERSIANGULF00107.IteratorFunction(Al Minhad AB)
2020-02-11 14:50:27.275 INFO    SCRIPTING:  48510( 13408)/E:        ATC_GROUND_PERSIANGULF00107.IteratorFunction(Abu Musa Island Airport)
2020-02-11 14:50:27.275 INFO    SCRIPTING:  48510( 13408)/E:        ATC_GROUND_PERSIANGULF00107.IteratorFunction(Sas Al Nakheel Airport)
2020-02-11 14:50:27.275 INFO    SCRIPTING:  48510( 13408)/E:        ATC_GROUND_PERSIANGULF00107.IteratorFunction(Qeshm Island)
2020-02-11 14:50:27.275 INFO    SCRIPTING:  48510( 13408)/E:        ATC_GROUND_PERSIANGULF00107.IteratorFunction(Havadarya)
2020-02-11 14:50:27.275 INFO    SCRIPTING:  48510( 13408)/E:        ATC_GROUND_PERSIANGULF00107.IteratorFunction(Al Maktoum Intl)```