### PR TITLE
FIX: removed Mellan_Airstrip from list of Nevada airfields (not a val…

### DIFF
--- a/Moose Development/Moose/Functional/ATC_Ground.lua
+++ b/Moose Development/Moose/Functional/ATC_Ground.lua
@@ -1052,7 +1052,6 @@ end
 --    * `AIRBASE.Nevada.Laughlin_Airport`
 --    * `AIRBASE.Nevada.Lincoln_County`
 --    * `AIRBASE.Nevada.McCarran_International_Airport`
---    * `AIRBASE.Nevada.Mellan_Airstrip`
 --    * `AIRBASE.Nevada.Mesquite`
 --    * `AIRBASE.Nevada.Mina_Airport_3Q0`
 --    * `AIRBASE.Nevada.Nellis_AFB`
@@ -1096,8 +1095,7 @@ end
 --    
 --     -- Monitor specific airbases.
 --     ATC_Ground = ATC_GROUND_NEVADA:New(              
---       { AIRBASE.Nevada.Laughlin_Airport,             
---         AIRBASE.Nevada.Mellan_Airstrip,              
+--       { AIRBASE.Nevada.Laughlin_Airport,                        
 --         AIRBASE.Nevada.Lincoln_County,               
 --         AIRBASE.Nevada.North_Las_Vegas,              
 --         AIRBASE.Nevada.McCarran_International_Airport

--- a/Moose Development/Moose/Wrapper/Airbase.lua
+++ b/Moose Development/Moose/Wrapper/Airbase.lua
@@ -124,7 +124,6 @@ AIRBASE.Caucasus = {
 --   * AIRBASE.Nevada.Jean_Airport
 --   * AIRBASE.Nevada.Laughlin_Airport
 --   * AIRBASE.Nevada.Lincoln_County
---   * AIRBASE.Nevada.Mellan_Airstrip
 --   * AIRBASE.Nevada.Mesquite
 --   * AIRBASE.Nevada.Mina_Airport_3Q0
 --   * AIRBASE.Nevada.North_Las_Vegas
@@ -144,7 +143,6 @@ AIRBASE.Nevada = {
   ["Jean_Airport"] = "Jean Airport",
   ["Laughlin_Airport"] = "Laughlin Airport",
   ["Lincoln_County"] = "Lincoln County",
-  ["Mellan_Airstrip"] = "Mellan Airstrip",
   ["Mesquite"] = "Mesquite",
   ["Mina_Airport_3Q0"] = "Mina Airport 3Q0",
   ["North_Las_Vegas"] = "North Las Vegas",


### PR DESCRIPTION
…id airport and has no taxiway designations, resulting in a scripting error if included)