### PR TITLE
Spawn init array #1255

### DIFF
--- a/Moose Development/Moose/Core/Spawn.lua
+++ b/Moose Development/Moose/Core/Spawn.lua
@@ -998,6 +998,7 @@ end
 
 --- Makes the groups visible before start (like a batallion).
 -- The method will take the position of the group as the first position in the array.
+-- CAUTION: this directive will NOT work with OnSpawnGroup function.
 -- @param #SPAWN self
 -- @param #number SpawnAngle The angle in degrees how the groups and each unit of the group will be positioned.
 -- @param #number SpawnWidth The amount of Groups that will be positioned on the X axis.


### PR DESCRIPTION
Issue to deep solve. Added a CAUTION in docs. 
Send issue to @FlightControl-User for eventually fix.

Solves #1255 

When using `function SPAWN:InitArray( SpawnAngle, SpawnWidth, SpawnDeltaX, SpawnDeltaY )` OnSpawnGroup is not called. Database is populated with groups which is not on the map.

Wingthor