### PR TITLE
Fixes & Improvements

### DIFF
--- a/Moose Development/Moose/Core/RadioQueue.lua
+++ b/Moose Development/Moose/Core/RadioQueue.lua
@@ -351,13 +351,21 @@ function RADIOQUEUE:Broadcast(transmission)
       self.senderinit=true
     end
     
+    -- Set subtitle only if duration>0 sec.
+    local subtitle=nil
+    local duration=nil
+    if transmission.subtitle and transmission.subduration and transmission.subduration>0 then
+      subtitle=transmission.subtitle
+      duration=transmission.subduration
+    end
+    
     -- Command to tranmit the call.
     local commandTransmit={
       id = "TransmitMessage",
       params = {
         file=filename,
-        duration=transmission.subduration,
-        subtitle=transmission.subtitle or "",
+        duration=duration,
+        subtitle=subtitle,
         loop=false,
       }}    
     

--- a/Moose Development/Moose/Ops/ATIS.lua
+++ b/Moose Development/Moose/Ops/ATIS.lua
@@ -130,6 +130,7 @@
 -- **Note** that you should use a different relay unit for each ATIS!
 --
 -- By default, subtitles are displayed for 10 seconds. This can be changed using @{#ATIS.SetSubtitleDuration}(*duration*) with *duration* being the duration in seconds.
+-- Setting a *duration* of 0 will completely disable all subtitles.
 --
 -- ## Active Runway
 --
@@ -523,7 +524,7 @@ _ATIS={}
 
 --- ATIS class version.
 -- @field #string version
-ATIS.version="0.6.3"
+ATIS.version="0.6.4"
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- TODO list
@@ -1537,6 +1538,7 @@ function ATIS:onafterBroadcast(From, Event, To)
   -- Runway length.
   if self.rwylength then
 
+    local runact=self.airbase:GetActiveRunway(self.runwaym2t)
     local length=runact.length
     if not self.metric then
       length=UTILS.MetersToFeet(length)

--- a/Moose Development/Moose/Utilities/Utils.lua
+++ b/Moose Development/Moose/Utilities/Utils.lua
@@ -474,8 +474,11 @@ UTILS.tostringMGRS = function(MGRS, acc) --R2.1
   if acc == 0 then
     return MGRS.UTMZone .. ' ' .. MGRS.MGRSDigraph
   else
-    return MGRS.UTMZone .. ' ' .. MGRS.MGRSDigraph .. ' ' .. string.format('%0' .. acc .. 'd', UTILS.Round(MGRS.Easting/(10^(5-acc)), 0))
-           .. ' ' .. string.format('%0' .. acc .. 'd', UTILS.Round(MGRS.Northing/(10^(5-acc)), 0))
+    --return MGRS.UTMZone .. ' ' .. MGRS.MGRSDigraph .. ' ' .. string.format('%0' .. acc .. 'd', UTILS.Round(MGRS.Easting/(10^(5-acc)), 0))
+    --       .. ' ' .. string.format('%0' .. acc .. 'd', UTILS.Round(MGRS.Northing/(10^(5-acc)), 0))
+    
+    -- Truncate rather than round MGRS grid!        
+    return string.format("%s %s %s %s", MGRS.UTMZone, MGRS.MGRSDigraph, string.sub(tostring(MGRS.Easting), 1, acc), string.sub(tostring(MGRS.Northing), 1, acc))
   end
 end
 


### PR DESCRIPTION
**RADIOQUEUE**
- If subtitle duration is 0 (or less), subtitle is not displayed (e.g. for ATIS class).

**ATIS v0.6.4**
- Fixed bug if runway length is given out.
- Docs.

**UTILS**
- Fixed bug in MGRS output. Easting and Northing values are truncated rather than rounded.

**AIRBASE**
- Workaround if airbase category could not be determined due to DCS 2.5.6 bugs. Assuming it's an airdrome for now.