### PR TITLE
Init group heading implementation

### DIFF
--- a/Moose Development/Moose/Wrapper/Group.lua
+++ b/Moose Development/Moose/Wrapper/Group.lua
@@ -316,9 +316,12 @@ function GROUP:GetPositionVec3() -- Overridden from POSITIONABLE:GetPositionVec3
   local DCSPositionable = self:GetDCSObject()
   
   if DCSPositionable then
-    local PositionablePosition = DCSPositionable:getUnits()[1]:getPosition().p
+   local unit = DCSPositionable:getUnits()[1]
+   if unit then
+     local PositionablePosition = unit:getPosition().p
     self:T3( PositionablePosition )
     return PositionablePosition
+    end
   end
   
   return nil
@@ -366,9 +369,11 @@ function GROUP:IsActive()
   local DCSGroup = self:GetDCSObject() -- DCS#Group
   
   if DCSGroup then
-  
-    local GroupIsActive = DCSGroup:getUnit(1):isActive()
+    local unit = DCSGroup:getUnit(1)
+    if unit then
+      local GroupIsActive = unit:isActive()
     return GroupIsActive 
+    end
   end
 
   return nil


### PR DESCRIPTION
This is an implementation of SPAWN:InitGroupHeading.  Like SPAWN:InitHeading, but affects the orientation of the entire group formation rather than just the individual units.

The implementation has very low footprint, and copies the approach used by SPAWN:InitHeading.  The InitGroupHeading sets a few values on the spawn object which are later used in SPAWN:SpawnWithIndex to adjust the unit positions and orientations.  This seems to be the only place the InitHeading settings were ever applied, so this should at least make InitGroupHeading apply whenever InitHeading will have applied.

I have utilised this implementation in a modified version of the persistent-world "Clear Field" mission to spawn user-constructed SAM sites and ground unit groups at whatever position and orientation they wish, and it has received several days of testing by my multiplayer squadron with no issues revealed, so I am pretty confident the implementation is solid.

