### PR TITLE
Fixes

### DIFF
--- a/Moose Development/Moose/AI/AI_A2G_Dispatcher.lua
+++ b/Moose Development/Moose/AI/AI_A2G_Dispatcher.lua
@@ -4375,7 +4375,7 @@ do -- AI_A2G_DISPATCHER
     
     Report:Add( string.format( "\n - Squadron Resources: ", #self.DefenseQueue ) )
     for DefenderSquadronName, DefenderSquadron in pairs( self.DefenderSquadrons ) do
-      Report:Add( string.format( "   - %s - %d", DefenderSquadronName, DefenderSquadron.ResourceCount and DefenderSquadron.ResourceCount or "n/a" ) )
+      Report:Add( string.format( "   - %s - %s", DefenderSquadronName, DefenderSquadron.ResourceCount and tostring(DefenderSquadron.ResourceCount) or "n/a" ) )
     end
 
     self:F( Report:Text( "\n" ) )

--- a/Moose Development/Moose/Core/Base.lua
+++ b/Moose Development/Moose/Core/Base.lua
@@ -771,6 +771,8 @@ end
 function BASE:onEvent(event)
   --self:F( { BaseEventCodes[event.id], event } )
 
+  env.info("FF BASE:onEvent id="..event.id)
+
 	if self then
 		for EventID, EventObject in pairs( self.Events ) do
 			if EventObject.EventEnabled then

--- a/Moose Development/Moose/Core/Base.lua
+++ b/Moose Development/Moose/Core/Base.lua
@@ -771,8 +771,6 @@ end
 function BASE:onEvent(event)
   --self:F( { BaseEventCodes[event.id], event } )
 
-  env.info("FF BASE:onEvent id="..event.id)
-
 	if self then
 		for EventID, EventObject in pairs( self.Events ) do
 			if EventObject.EventEnabled then

--- a/Moose Development/Moose/Core/Event.lua
+++ b/Moose Development/Moose/Core/Event.lua
@@ -1063,6 +1063,7 @@ function EVENT:onEvent( Event )
         if Event.id==EVENTS.LandingAfterEjection then
           -- Place is here the UNIT of which the pilot ejected.
           --local name=Event.place:getName()  -- This returns a DCS error "Airbase doesn't exit" :(
+          -- However, this is not a big thing, as the aircraft the pilot ejected from is usually long crashed before the ejected pilot touches the ground.
           --Event.Place=UNIT:Find(Event.place)
         else   
           Event.Place=AIRBASE:Find(Event.place)

--- a/Moose Development/Moose/Core/Event.lua
+++ b/Moose Development/Moose/Core/Event.lua
@@ -963,7 +963,7 @@ function EVENT:onEvent( Event )
         
         if Event.IniObjectCategory == Object.Category.STATIC then
           if Event.id==31 then
-            env.info("FF event 31")
+            --env.info("FF event 31")
             -- Event.initiator is a Static object representing the pilot. But getName() error due to DCS bug.
             Event.IniDCSUnit = Event.initiator
             local ID=Event.initiator.id_
@@ -971,7 +971,6 @@ function EVENT:onEvent( Event )
             Event.IniUnitName = Event.IniDCSUnitName
             Event.IniCoalition = 0
             Event.IniCategory  = 0
-            Event.IniUnit=STATIC:Register(Event.IniUnitName)
             Event.IniTypeName = "Ejected Pilot"
           else
             Event.IniDCSUnit = Event.initiator
@@ -1063,6 +1062,7 @@ function EVENT:onEvent( Event )
       if Event.place then   
         if Event.id==EVENTS.LandingAfterEjection then
           -- Place is here the UNIT of which the pilot ejected.
+          --local name=Event.place:getName()  -- This returns a DCS error "Airbase doesn't exit" :(
           --Event.Place=UNIT:Find(Event.place)
         else   
           Event.Place=AIRBASE:Find(Event.place)
@@ -1098,30 +1098,13 @@ function EVENT:onEvent( Event )
         self:F( { EventMeta.Text, Event, Event.IniDCSUnitName, Event.TgtDCSUnitName, PriorityOrder } )
       end
       
-      --self:E({Events=self.Events})
-      --self:E({Events31=self.Events[31]})
-      
-      env.info(string.format("FF %s all events:", EventMeta.Text))
-      for id,data in pairs(self.Events) do
-        self:E({id=id, data=data})      
-      end
-      
       for EventPriority = PriorityBegin, PriorityEnd, PriorityOrder do
-      
-        env.info("hallo 100 EventPriority="..EventPriority)
       
         if self.Events[Event.id][EventPriority] then
         
-          env.info("hallo 200")
-          self:E({blub=EventMeta.Text, bla=self.Events[Event.id][EventPriority]})
-        
           -- Okay, we got the event from DCS. Now loop the SORTED self.EventSorted[] table for the received Event.id, and for each EventData registered, check if a function needs to be called.
           for EventClass, EventData in pairs( self.Events[Event.id][EventPriority] ) do
-          
-            env.info("hallo 300")
-            self:E({eventclass=EventClass})
-            self:E({eventdata=EventData})
-          
+                    
             --if Event.IniObjectCategory ~= Object.Category.STATIC then
             --  self:E( { "Evaluating: ", EventClass:GetClassNameAndID() } )
             --end

--- a/Moose Development/Moose/Core/Event.lua
+++ b/Moose Development/Moose/Core/Event.lua
@@ -555,6 +555,8 @@ function EVENT:Init( EventID, EventClass )
   if not self.Events[EventID][EventPriority][EventClass] then
      self.Events[EventID][EventPriority][EventClass] = {}
   end
+  
+  
   return self.Events[EventID][EventPriority][EventClass]
 end
 
@@ -641,7 +643,7 @@ end
 -- @param EventID
 -- @return #EVENT
 function EVENT:OnEventGeneric( EventFunction, EventClass, EventID )
-  self:F2( { EventID } )
+  self:F2( { EventID, EventClass, EventFunction } )
 
   local EventData = self:Init( EventID, EventClass )
   EventData.EventFunction = EventFunction
@@ -960,13 +962,26 @@ function EVENT:onEvent( Event )
         end
         
         if Event.IniObjectCategory == Object.Category.STATIC then
-          Event.IniDCSUnit = Event.initiator
-          Event.IniDCSUnitName = Event.IniDCSUnit:getName()
-          Event.IniUnitName = Event.IniDCSUnitName
-          Event.IniUnit = STATIC:FindByName( Event.IniDCSUnitName, false )
-          Event.IniCoalition = Event.IniDCSUnit:getCoalition()
-          Event.IniCategory = Event.IniDCSUnit:getDesc().category
-          Event.IniTypeName = Event.IniDCSUnit:getTypeName()
+          if Event.id==31 then
+            env.info("FF event 31")
+            -- Event.initiator is a Static object representing the pilot. But getName() error due to DCS bug.
+            Event.IniDCSUnit = Event.initiator
+            local ID=Event.initiator.id_
+            Event.IniDCSUnitName = string.format("Ejected Pilot ID %s", tostring(ID))
+            Event.IniUnitName = Event.IniDCSUnitName
+            Event.IniCoalition = 0
+            Event.IniCategory  = 0
+            Event.IniUnit=STATIC:Register(Event.IniUnitName)
+            Event.IniTypeName = "Ejected Pilot"
+          else
+            Event.IniDCSUnit = Event.initiator
+            Event.IniDCSUnitName = Event.IniDCSUnit:getName()
+            Event.IniUnitName = Event.IniDCSUnitName
+            Event.IniUnit = STATIC:FindByName( Event.IniDCSUnitName, false )
+            Event.IniCoalition = Event.IniDCSUnit:getCoalition()
+            Event.IniCategory = Event.IniDCSUnit:getDesc().category
+            Event.IniTypeName = Event.IniDCSUnit:getTypeName()
+          end
         end
   
         if Event.IniObjectCategory == Object.Category.CARGO then
@@ -1048,7 +1063,7 @@ function EVENT:onEvent( Event )
       if Event.place then   
         if Event.id==EVENTS.LandingAfterEjection then
           -- Place is here the UNIT of which the pilot ejected.
-          Event.Place=UNIT:Find(Event.place)
+          --Event.Place=UNIT:Find(Event.place)
         else   
           Event.Place=AIRBASE:Find(Event.place)
           Event.PlaceName=Event.Place:GetName()
@@ -1083,12 +1098,29 @@ function EVENT:onEvent( Event )
         self:F( { EventMeta.Text, Event, Event.IniDCSUnitName, Event.TgtDCSUnitName, PriorityOrder } )
       end
       
+      --self:E({Events=self.Events})
+      --self:E({Events31=self.Events[31]})
+      
+      env.info(string.format("FF %s all events:", EventMeta.Text))
+      for id,data in pairs(self.Events) do
+        self:E({id=id, data=data})      
+      end
+      
       for EventPriority = PriorityBegin, PriorityEnd, PriorityOrder do
+      
+        env.info("hallo 100 EventPriority="..EventPriority)
       
         if self.Events[Event.id][EventPriority] then
         
+          env.info("hallo 200")
+          self:E({blub=EventMeta.Text, bla=self.Events[Event.id][EventPriority]})
+        
           -- Okay, we got the event from DCS. Now loop the SORTED self.EventSorted[] table for the received Event.id, and for each EventData registered, check if a function needs to be called.
           for EventClass, EventData in pairs( self.Events[Event.id][EventPriority] ) do
+          
+            env.info("hallo 300")
+            self:E({eventclass=EventClass})
+            self:E({eventdata=EventData})
           
             --if Event.IniObjectCategory ~= Object.Category.STATIC then
             --  self:E( { "Evaluating: ", EventClass:GetClassNameAndID() } )
@@ -1145,10 +1177,11 @@ function EVENT:onEvent( Event )
               else
                 -- The EventClass is not alive anymore, we remove it from the EventHandlers...
                 self:RemoveEvent( EventClass, Event.id )
-              end                      
+              end
+              
             else
   
-              -- If the EventData is for a GROUP, the call directly the EventClass EventFunction for the UNIT in that GROUP.
+              --- If the EventData is for a GROUP, the call directly the EventClass EventFunction for the UNIT in that GROUP.
               if EventData.EventGroup then
   
                 -- So now the EventClass must be a GROUP class!!! We check if it is still "Alive".


### PR DESCRIPTION
**EVENT**
- Fixes error for LANDING_AFTER_EJECTION event. Name of static pilot object cannot be retriefed by `:getName()` function. DCS bug!
- Fixes error for LANDING_AFTER_EJECTION event: Event.place should be the aircraft the pilot ejected from. But it is mostly nil as the aircraft already crashed before the pilot touches the ground. This also caused an output "Airbase doen't exist" in the dcs.log file.

**A2G_DISPATCHER**
- Fixed output format in report. See issue #1303 