### PR TITLE
Added call to self:UpdateTaskInfo( self.DetectedItem ) to RerportOrde…

### DIFF
--- a/Moose Development/Moose/Tasking/Task_A2A.lua
+++ b/Moose Development/Moose/Tasking/Task_A2A.lua
@@ -292,7 +292,9 @@ do -- TASK_A2A
 
   --- Return the relative distance to the target vicinity from the player, in order to sort the targets in the reports per distance from the threats.
   -- @param #TASK_A2A self
-  function TASK_A2A:ReportOrder( ReportGroup ) 
+  function TASK_A2A:ReportOrder( ReportGroup )
+	self:UpdateTaskInfo( self.DetectedItem )
+  
     local Coordinate = self.TaskInfo:GetData( "Coordinate" )
     local Distance = ReportGroup:GetCoordinate():Get2DDistance( Coordinate )
     

--- a/Moose Development/Moose/Tasking/Task_A2G.lua
+++ b/Moose Development/Moose/Tasking/Task_A2G.lua
@@ -295,6 +295,8 @@ do -- TASK_A2G
   --- Return the relative distance to the target vicinity from the player, in order to sort the targets in the reports per distance from the threats.
   -- @param #TASK_A2G self
   function TASK_A2G:ReportOrder( ReportGroup ) 
+	self:UpdateTaskInfo( self.DetectedItem )
+  
     local Coordinate = self.TaskInfo:GetData( "Coordinate" )
     local Distance = ReportGroup:GetCoordinate():Get2DDistance( Coordinate )
     


### PR DESCRIPTION
…r for both Task_A2A and Task_A2G. This fixes an issue with multi task missions where coordinates are not available when Moose attempts to sort the tasks for the comms menu.