### PR TITLE
Modify ATIS format to more closely match real world

### DIFF
--- a/Moose Development/Moose/Ops/ATIS.lua
+++ b/Moose Development/Moose/Ops/ATIS.lua
@@ -1387,13 +1387,24 @@ function ATIS:onafterBroadcast(From, Event, To)
       visibilitymin=dust
     end
   end
+  
+  local VISIBILITY=""
 
-  -- Visibility in NM.
-  local VISIBILITY=string.format("%d", UTILS.Round(UTILS.MetersToNM(visibilitymin)))
-
-  -- Visibility in km.
   if self.metric then
-    VISIBILITY=string.format("%d", UTILS.Round(visibilitymin/1000))
+    -- Visibility in km.
+    local reportedviz=UTILS.Round(visibilitymin/1000)
+    -- max reported visibility 9999 m
+    if reportedviz > 10 then
+      reportedviz=10
+    end
+    VISIBILITY=string.format("%d", reportedviz)
+  else
+    -- max reported visibility 10 NM
+    local reportedviz=UTILS.Round(UTILS.MetersToNM(visibilitymin))
+    if reportedviz > 10 then
+      reportedviz=10
+    end
+    VISIBILITY=string.format("%d", reportedviz)
   end
 
   --------------

--- a/Moose Development/Moose/Ops/ATIS.lua
+++ b/Moose Development/Moose/Ops/ATIS.lua
@@ -432,6 +432,7 @@ ATIS.ICAOPhraseology={
 -- @field #ATIS.Soundfile MegaHertz
 -- @field #ATIS.Soundfile Meters
 -- @field #ATIS.Soundfile MetersPerSecond
+-- @field #ATIS.Soundfile Miles
 -- @field #ATIS.Soundfile MillimetersOfMercury
 -- @field #ATIS.Soundfile N0
 -- @field #ATIS.Soundfile N1
@@ -504,6 +505,7 @@ ATIS.Sound = {
   MegaHertz={filename="MegaHertz.ogg", duration=0.87},
   Meters={filename="Meters.ogg", duration=0.59},
   MetersPerSecond={filename="MetersPerSecond.ogg", duration=1.14},
+  Miles={filename="Miles.ogg", duration=1.04},
   MillimetersOfMercury={filename="MillimetersOfMercury.ogg", duration=1.53},
   Minus={filename="Minus.ogg", duration=0.64},
   N0={filename="N-0.ogg", duration=0.55},
@@ -1400,7 +1402,7 @@ function ATIS:onafterBroadcast(From, Event, To)
     VISIBILITY=string.format("%d", reportedviz)
   else
     -- max reported visibility 10 NM
-    local reportedviz=UTILS.Round(UTILS.MetersToNM(visibilitymin))
+    local reportedviz=UTILS.Round(UTILS.MetersToSM(visibilitymin))
     if reportedviz > 10 then
       reportedviz=10
     end
@@ -1540,14 +1542,14 @@ function ATIS:onafterBroadcast(From, Event, To)
   if self.metric then
     subtitle=string.format("Visibility %s km", VISIBILITY)
   else
-    subtitle=string.format("Visibility %s NM", VISIBILITY)
+    subtitle=string.format("Visibility %s SM", VISIBILITY)
   end
   self:Transmission(ATIS.Sound.Visibilty, 1.0, subtitle)
   self.radioqueue:Number2Transmission(VISIBILITY)
   if self.metric then
     self:Transmission(ATIS.Sound.Kilometers, 0.2)
   else
-    self:Transmission(ATIS.Sound.NauticalMiles, 0.2)
+    self:Transmission(ATIS.Sound.Miles, 0.2)
   end
   alltext=alltext..";\n"..subtitle
   

--- a/Moose Development/Moose/Ops/ATIS.lua
+++ b/Moose Development/Moose/Ops/ATIS.lua
@@ -373,6 +373,19 @@ ATIS.RunwayM2T={
   PersianGulf=2,
 }
 
+--- Whether ICAO phraseology is used for ATIS broadcasts.
+-- @type ATIS.ICAOPhraseology
+-- @field #boolean Caucasus true.
+-- @field #boolean Nevada false.
+-- @field #boolean Normandy true.
+-- @field #boolean PersianGulf true.
+ATIS.ICAOPhraseology={
+  Caucasus=true,
+  Nevada=false,
+  Normandy=true,
+  PersianGulf=true
+}
+
 --- Nav point data.
 -- @type ATIS.NavPoint
 -- @field #number frequency Nav point frequency.
@@ -1700,13 +1713,18 @@ function ATIS:onafterBroadcast(From, Event, To)
     self:Transmission(ATIS.Sound.QNH, 0.5)
   end
   self.radioqueue:Number2Transmission(QNH[1])
-  self:Transmission(ATIS.Sound.Decimal, 0.2)
+
+  if ATIS.ICAOPhraseology[UTILS.GetDCSMap()] then
+    self:Transmission(ATIS.Sound.Decimal, 0.2)
+  end
   self.radioqueue:Number2Transmission(QNH[2])
   
   if not self.qnhonly then
     self:Transmission(ATIS.Sound.QFE, 0.75)
     self.radioqueue:Number2Transmission(QFE[1])
-    self:Transmission(ATIS.Sound.Decimal, 0.2)
+    if ATIS.ICAOPhraseology[UTILS.GetDCSMap()] then
+      self:Transmission(ATIS.Sound.Decimal, 0.2)
+    end
     self.radioqueue:Number2Transmission(QFE[2])
   end
   

--- a/Moose Development/Moose/Ops/ATIS.lua
+++ b/Moose Development/Moose/Ops/ATIS.lua
@@ -365,7 +365,7 @@ ATIS.Alphabet = {
 ATIS.RunwayM2T={
   Caucasus=0,
   Nevada=12,
-  Normany=-10,
+  Normandy=-10,
   PersianGulf=2,
 }
 

--- a/Moose Development/Moose/Utilities/Utils.lua
+++ b/Moose Development/Moose/Utilities/Utils.lua
@@ -313,6 +313,10 @@ UTILS.MetersToNM = function(meters)
   return meters/1852
 end
 
+UTILS.MetersToSM = function(meters)
+  return meters/1609.34
+end
+
 UTILS.MetersToFeet = function(meters)
   return meters/0.3048
 end


### PR DESCRIPTION
This PR makes the following changes to Ops.ATIS:

**Re-orders ATIS elements to match real world:** A real-world ATIS always comes in a specific order: Airport, information, Zulu time, winds, weather, visibility, cloud layers, temperature, dew point, altimeter, remarks. This reorders the broadcast to match that order.

**Adds an option to suppress additional time information:** The standard ATIS does not include local time, sunrise, sunset, etc. information, only Zulu time. The `ATIS:ReportZuluTimeOnly` method has been added to replicate this behavior.

**Adds an option to suppress reporting of QFE:** QFE is not reported at US airports as well as at many other countries. This PR adds the `ATIS:ReportQNHOnly` method to suppress reporting QFE. In addition, the term "QNH" is not used in US airports, only "altimeter"; calling that method replicates this standard.

**Does not use ICAO phraseology for US theaters:** US standard phraseology does not use the word "decimal". This PR suppresses the word "decimal" for the Nevada theater.

**Does not report visibilities higher than 10 miles or 9999 meters:** Transmissometers do not report values higher than 10 SM or 9999 meters, and human-created ATISes will only report visibility as "greater than 10 miles". This PR clamps reported visibilities to 10 miles or 9999 meters, depending on whether English or metric units are used.

**Uses statute miles instead of nautical miles for visibility:** Visibility is reported in statute miles, not nautical miles. This PR adds the `MetersToSM` method to `UTILS` and changes the ATIS transmission to say "miles" instead of "nautical miles". **Note that the ATIS Soundfile pack will have to be updated to include a "Miles.ogg" file for this commit.**

Potential (debatable) areas for improvement:

* I would argue that, in the interest of realism, the ATIS should report only Zulu time by default, and report only QNH by default, with the user instead having to opt-in to getting the extended time and altimeter information. However, in the interest of preserving existing behavior, I have made these options opt-out instead.
* I've opted to leave in "gusting" though I think it should perhaps be taken out. "Gusting" is only used when wind speeds vary from the average by more than 50%, and the gust speed is reported (e.g., "wind 290 at 10 knots gusting 30 knots"). Currently the word "gusting" is appended if there is turbulence, with no gust speed. To my ears it just sounds like a bug ("wait, what's the gust speed?") and should be left out.
* "Winds from" and WindsFrom.ogg should be changed to "Wind" to match standard phraseology (e.g., "wind 290 at 10 knots").
* Could make the reporting of QNH vs. QFE automatic based on theater (e.g., Caucasus would report QFE and all other theaters would report QNH). Would be easy enough to do.