### PR TITLE
Add new Routing Function to Controllable.lua

### DIFF
--- a/Moose Development/Moose/Wrapper/Controllable.lua
+++ b/Moose Development/Moose/Wrapper/Controllable.lua
@@ -129,6 +129,7 @@
 --   * @{#CONTROLLABLE.Route}(): Make the Controllable to follow a given route.
 --   * @{#CONTROLLABLE.RouteGroundTo}(): Make the GROUND Controllable to drive towards a specific coordinate.
 --   * @{#CONTROLLABLE.RouteAirTo}(): Make the AIR Controllable to fly towards a specific coordinate.
+--   * @{CONTROLLABLE.RelocateGroundRandomInRadius}(): Relocate the GROUND controllable to a random point in a given radius.
 --
 -- # 5) Option methods
 --
@@ -3712,4 +3713,34 @@ function CONTROLLABLE:OptionEngageRange(EngageRange)
    return self
   end
   return nil
+end
+
+--- (GROUND) Relocate controllable to a random point within a given radius; use e.g.for evasive actions; Note that not all ground controllables can actually drive, also the alarm state of the controllable might stop it from moving.
+-- @param #CONTROLLABLE self
+-- @param  #number speed Speed of the controllable, default 20
+-- @param  #number radius Radius of the relocation zone, default 500
+-- @param  #boolean onroad If true, route on road (less problems with AI way finding), default true
+-- @param  #boolean shortcut If true and onroad is set, take a shorter route - if available - off road, default false
+function CONTROLLABLE:RelocateGroundRandomInRadius(speed, radius, onroad, shortcut)
+  self:F2( { self.ControllableName } ) 
+
+    local _coord = self:GetCoordinate() 
+    local _radius = radius or 500
+    local _speed = speed or 20
+    local _tocoord = _coord:GetRandomCoordinateInRadius(_radius,100)
+    local _onroad = onroad or true
+    local _grptsk = {}
+    local _candoroad = false
+    local _shortcut = shortcut or false
+    
+    -- create a DCS Task an push it on the group
+    -- TaskGroundOnRoad(ToCoordinate,Speed,OffRoadFormation,Shortcut,FromCoordinate,WaypointFunction,WaypointFunctionArguments)
+    if onroad then
+      _grptsk, _candoroad = self:TaskGroundOnRoad(_tocoord,_speed,"Off Road",_shortcut)
+      self:Route(_grptsk,5)
+    else
+      self:TaskRouteToVec2(_tocoord:GetVec2(),_speed,"Off Road")
+    end
+
+  return self    
 end


### PR DESCRIPTION
--- (GROUND) Relocate controllable to a random point within a given radius; use e.g.for evasive actions; Note that not all ground controllables can actually drive, also the alarm state of the controllable might stop it from moving.
-- @param #CONTROLLABLE self
-- @param  #number speed Speed of the controllable, default 20
-- @param  #number radius Radius of the relocation zone, default 500
-- @param  #boolean onroad If true, route on road (less problems with AI way finding), default true
-- @param  #boolean shortcut If true and onroad is set, take a shorter route - if available - off road, default false