### PR TITLE
Update AirWing.lua

### DIFF
--- a/Moose Development/Moose/Ops/AirWing.lua
+++ b/Moose Development/Moose/Ops/AirWing.lua
@@ -1464,7 +1464,9 @@ function AIRWING:onafterMissionCancel(From, Event, To, Mission)
   -- Info message.
   self:I(self.lid..string.format("Cancel mission %s", Mission.name))
   
-  if Mission:IsPlanned() or Mission:IsQueued() or Mission:IsRequested() then
+  local Ngroups = Mission:CountOpsGroups()
+  
+  if Mission:IsPlanned() or Mission:IsQueued() or Mission:IsRequested() or Ngroups == 0 then
   
     Mission:Done()
   


### PR DESCRIPTION
Avoid loop if mission is governed by an Airwing. Mission cancel will ask airwing to cancel will ask flightgroup to cancel, which doesn't work if the latter is dead. Rare but happens.