### PR TITLE
ZONES and COORDINATES: New functions to draw on F10 map

### DIFF
--- a/Moose Development/Moose/Core/Database.lua
+++ b/Moose Development/Moose/Core/Database.lua
@@ -298,24 +298,81 @@ do -- Zones
   -- @return #DATABASE self
   function DATABASE:_RegisterZones()
 
-    for ZoneID, ZoneData in pairs( env.mission.triggers.zones ) do
+    for ZoneID, ZoneData in pairs(env.mission.triggers.zones) do
       local ZoneName = ZoneData.name
+      
+      -- Color
+      local color=ZoneData.color or {1, 0, 0, 0.15}
+      
+      -- Create new Zone
+      local Zone=nil   --Core.Zone#ZONE_BASE
+      
+      if ZoneData.type==0 then
+      
+        ---
+        -- Circular zone
+        ---
+        
+        self:I(string.format("Register ZONE: %s (Circular)", ZoneName))
+        
+        Zone=ZONE:New(ZoneName)
+          
+      else
 
-      self:I( { "Register ZONE:", Name = ZoneName } )
-      local Zone = ZONE:New( ZoneName )
-      self.ZONENAMES[ZoneName] = ZoneName
-      self:AddZone( ZoneName, Zone )
+        ---
+        -- Quad-point zone
+        ---
+
+        self:I(string.format("Register ZONE: %s (Polygon, Quad)", ZoneName))
+              
+        Zone=ZONE_POLYGON_BASE:New(ZoneName, ZoneData.verticies)
+        
+        for i,vec2 in pairs(ZoneData.verticies) do
+          local coord=COORDINATE:NewFromVec2(vec2)
+          coord:MarkToAll(string.format("%s Point %d", ZoneName, i))
+        end
+      
+      end
+      
+      if Zone then
+
+        -- Debug output.
+        --self:I({"Register ZONE: %s (", Name = ZoneName})
+        
+        Zone.Color=color
+
+      
+        -- Store in DB.
+        self.ZONENAMES[ZoneName] = ZoneName
+        
+        -- Add zone.
+        self:AddZone(ZoneName, Zone)
+        
+      end
+      
     end
 
+    -- Polygon zones defined by late activated groups.
     for ZoneGroupName, ZoneGroup in pairs( self.GROUPS ) do
       if ZoneGroupName:match("#ZONE_POLYGON") then
+      
         local ZoneName1 = ZoneGroupName:match("(.*)#ZONE_POLYGON")
         local ZoneName2 = ZoneGroupName:match(".*#ZONE_POLYGON(.*)")
         local ZoneName = ZoneName1 .. ( ZoneName2 or "" )
 
-        self:I( { "Register ZONE_POLYGON:", Name = ZoneName } )
+        -- Debug output
+        self:I(string.format("Register ZONE: %s (Polygon)", ZoneName))
+        
+        -- Create a new polygon zone.
         local Zone_Polygon = ZONE_POLYGON:New( ZoneName, ZoneGroup )
+        
+        -- Set color.
+        Zone_Polygon:SetColor({1, 0, 0}, 0.15)
+        
+        -- Store name in DB.
         self.ZONENAMES[ZoneName] = ZoneName
+        
+        -- Add zone to DB.
         self:AddZone( ZoneName, Zone_Polygon )
       end
     end

--- a/Moose Development/Moose/Core/Event.lua
+++ b/Moose Development/Moose/Core/Event.lua
@@ -1000,7 +1000,7 @@ function EVENT:onEvent( Event )
   -- Check if this is a known event?
   if EventMeta then
 
-    if self and self.Events and self.Events[Event.id] and self.MissionEnd==false and (Event.initiator~=nil or (Event.initiator==nil and Event.idss~=EVENTS.PlayerLeaveUnit)) then
+    if self and self.Events and self.Events[Event.id] and self.MissionEnd==false and (Event.initiator~=nil or (Event.initiator==nil and Event.id~=EVENTS.PlayerLeaveUnit)) then
 
       if Event.id and Event.id == EVENTS.MissionEnd then
         self.MissionEnd = true

--- a/Moose Development/Moose/Core/Event.lua
+++ b/Moose Development/Moose/Core/Event.lua
@@ -1008,37 +1008,13 @@ function EVENT:onEvent( Event )
   -- Check if this is a known event?
   if EventMeta then
 
-    env.info("FF some event 100 ID="..tostring(Event.id))
-
-    if Event.id==31 then
-       env.info("FF got event 31")
-       local initiator=Event.initiator~=nil
-       env.info(string.format("FF got event 31 initiator=%s", tostring(initiator)))
-       if self then
-         env.info(string.format("FF got event 31 self=true"))
-       end
-       if self.Events then
-         env.info(string.format("FF got event 31 self.Events=true"))
-       end
-       if self.Events[Event.id] then
-         env.info(string.format("FF got event 31 self.Events[Event.id]=true"))
-       else
-        env.info(string.format("FF NO event 31 self.Events[Event.id]=FALSE!"))
-       end
-    end
-
-    --if self and self.Events and self.Events[Event.id] and self.MissionEnd==false and (Event.initiator~=nil or (Event.initiator==nil and Event.idss~=EVENTS.PlayerLeaveUnit)) then
-    if self and self.Events and self.MissionEnd==false and (Event.initiator~=nil or (Event.initiator==nil and Event.idss~=EVENTS.PlayerLeaveUnit)) then
+    if self and self.Events and self.Events[Event.id] and self.MissionEnd==false and (Event.initiator~=nil or (Event.initiator==nil and Event.idss~=EVENTS.PlayerLeaveUnit)) then
 
       if Event.id and Event.id == EVENTS.MissionEnd then
         self.MissionEnd = true
       end
 
-      env.info("FF some event 150")
-
       if Event.initiator then
-
-        env.info("FF some event 200")
 
         Event.IniObjectCategory = Event.initiator:getCategory()
 
@@ -1068,11 +1044,7 @@ function EVENT:onEvent( Event )
 
         if Event.IniObjectCategory == Object.Category.STATIC then
 
-          env.info("FF some event 300")
-
           if Event.id==31 then
-
-            env.info("FF event 31")
 
             -- Event.initiator is a Static object representing the pilot. But getName() errors due to DCS bug.
             Event.IniDCSUnit = Event.initiator

--- a/Moose Development/Moose/Core/Event.lua
+++ b/Moose Development/Moose/Core/Event.lua
@@ -578,10 +578,6 @@ function EVENT:New()
   -- Add world event handler.
   self.EventHandler = world.addEventHandler(self)
 
-  for _,Event in pairs(self.Events) do
-    self:Init(Event,EventClass)
-  end
-
   return self
 end
 

--- a/Moose Development/Moose/Core/Event.lua
+++ b/Moose Development/Moose/Core/Event.lua
@@ -592,9 +592,7 @@ end
 -- @param Core.Base#BASE EventClass The class object for which events are handled.
 -- @return #EVENT.Events
 function EVENT:Init( EventID, EventClass )
-  self:I( { _EVENTMETA[EventID].Text, EventClass } )
-
-  env.info("FF EVENT.Init ID="..EventID)
+  self:F( { _EVENTMETA[EventID].Text, EventClass } )
 
   if not self.Events[EventID] then
     -- Create a WEAK table to ensure that the garbage collector is cleaning the event links when the object usage is cleaned.
@@ -988,8 +986,6 @@ end
 -- @param #EVENT self
 -- @param #EVENTDATA Event Event data table.
 function EVENT:onEvent( Event )
-
-  env.info("FF some event")
 
   local ErrorHandler = function( errmsg )
 

--- a/Moose Development/Moose/Core/Fsm.lua
+++ b/Moose Development/Moose/Core/Fsm.lua
@@ -540,7 +540,7 @@ do -- FSM
   
   --- Returns a table with the scores defined.
   -- @param #FSM self
-  -- @param #table Scores.
+  -- @return #table Scores.
   function FSM:GetScores()  
     return self._Scores or {}
   end

--- a/Moose Development/Moose/Core/Point.lua
+++ b/Moose Development/Moose/Core/Point.lua
@@ -634,9 +634,9 @@ do -- COORDINATE
 
   --- Return a random Coordinate within an Outer Radius and optionally NOT within an Inner Radius of the COORDINATE.
   -- @param #COORDINATE self
-  -- @param DCS#Distance OuterRadius
-  -- @param DCS#Distance InnerRadius
-  -- @return #COORDINATE
+  -- @param DCS#Distance OuterRadius Outer radius in meters.
+  -- @param DCS#Distance InnerRadius Inner radius in meters.
+  -- @return #COORDINATE self
   function COORDINATE:GetRandomCoordinateInRadius( OuterRadius, InnerRadius )
     self:F2( { OuterRadius, InnerRadius } )
 
@@ -2172,8 +2172,8 @@ do -- COORDINATE
     -- @param #table Color RGB color table {r, g, b}, e.g. {1,0,0} for red (default).
     -- @param #number Alpha Transparency [0,1]. Default 1.
     -- @param #table FillColor RGB color table {r, g, b}, e.g. {1,0,0} for red. Default is same as `Color` value.
-    -- @param #number FillAlpha Transparency [0,1]. Default 0.15.
-    -- @param #number FontSize Font size.    
+    -- @param #number FillAlpha Transparency [0,1]. Default 0.3.
+    -- @param #number FontSize Font size. Default 14.
     -- @param #boolean ReadOnly (Optional) Mark is readonly and cannot be removed by users. Default false.
     -- @return #number The resulting Mark ID, which is a number. Can be used to remove the object again. 
     function COORDINATE:TextToAll(Text, Coalition, Color, Alpha, FillColor, FillAlpha, FontSize, ReadOnly)
@@ -2185,8 +2185,8 @@ do -- COORDINATE
       Color=Color or {1,0,0}
       Color[4]=Alpha or 1.0
       FillColor=FillColor or Color
-      FillColor[4]=FillAlpha or 0.15      
-      FontSize=FontSize or 12
+      FillColor[4]=FillAlpha or 0.3
+      FontSize=FontSize or 14
       trigger.action.textToAll(Coalition, MarkID, self:GetVec3(), Color, FillColor, FontSize, ReadOnly, Text or "Hello World")
       return MarkID
     end

--- a/Moose Development/Moose/Core/Point.lua
+++ b/Moose Development/Moose/Core/Point.lua
@@ -164,6 +164,7 @@ do -- COORDINATE
   --
   --   * @{#COORDINATE.WaypointAir}(): Build an air route point.
   --   * @{#COORDINATE.WaypointGround}(): Build a ground route point.
+  --   * @{#COORDINATE.WaypointNaval}(): Build a naval route point.
   --
   -- Route points can be used in the Route methods of the @{Wrapper.Group#GROUP} class.
   --
@@ -183,9 +184,17 @@ do -- COORDINATE
   --
   -- ## 9) Coordinate text generation
   -- 
-  --
   --   * @{#COORDINATE.ToStringBR}(): Generates a Bearing & Range text in the format of DDD for DI where DDD is degrees and DI is distance.
   --   * @{#COORDINATE.ToStringLL}(): Generates a Latutude & Longutude text.
+  --
+  -- ## 10) Drawings on F10 map
+  -- 
+  --   * @{#COORDINATE.CircleToAll}(): Draw a circle on the F10 map.
+  --   * @{#COORDINATE.LineToAll}(): Draw a line on the F10 map.
+  --   * @{#COORDINATE.RectToAll}(): Draw a rectangle on the F10 map.
+  --   * @{#COORDINATE.QuadToAll}(): Draw a shape with four points on the F10 map.
+  --   * @{#COORDINATE.TextToAll}(): Write some text on the F10 map.
+  --   * @{#COORDINATE.ArrowToAll}(): Draw an arrow on the F10 map.
   --
   -- @field #COORDINATE
   COORDINATE = {
@@ -1984,13 +1993,13 @@ do -- COORDINATE
     -- @param #COORDINATE self
     -- @param #COORDINATE Endpoint COORDIANTE to where the line is drawn.
     -- @param #number Coalition Coalition: All=-1, Neutral=0, Red=1, Blue=2. Default -1=All.
-    -- @param #number LineType Line type: 0=No line, 1=Solid, 2=Dashed, 3=Dotted, 4=Dot dash, 5=Long dash, 6=Two dash. Default 1=Solid.
     -- @param #table Color RGB color table {r, g, b}, e.g. {1,0,0} for red (default).
     -- @param #number Alpha Transparency [0,1]. Default 1.
+    -- @param #number LineType Line type: 0=No line, 1=Solid, 2=Dashed, 3=Dotted, 4=Dot dash, 5=Long dash, 6=Two dash. Default 1=Solid.    
     -- @param #boolean ReadOnly (Optional) Mark is readonly and cannot be removed by users. Default false.
     -- @param #string Text (Optional) Text displayed when mark is added. Default none.
-    -- @return #number The resulting Mark ID which is a number.
-    function COORDINATE:LineToAll(Endpoint, Coalition, LineType, Color, Alpha, ReadOnly, Text)
+    -- @return #number The resulting Mark ID, which is a number. Can be used to remove the object again. 
+    function COORDINATE:LineToAll(Endpoint, Coalition, Color, Alpha, LineType, ReadOnly, Text)
       local MarkID = UTILS.GetMarkID()
       if ReadOnly==nil then
         ReadOnly=false
@@ -2007,18 +2016,17 @@ do -- COORDINATE
     --- Circle to all.
     -- Creates a circle on the map with a given radius, color, fill color, and outline.
     -- @param #COORDINATE self
-    -- @param #COORDINATE Center COORDIANTE of the center of the circle.
     -- @param #numberr Radius Radius in meters. Default 1000 m.
     -- @param #number Coalition Coalition: All=-1, Neutral=0, Red=1, Blue=2. Default -1=All.
-    -- @param #number LineType Line type: 0=No line, 1=Solid, 2=Dashed, 3=Dotted, 4=Dot dash, 5=Long dash, 6=Two dash. Default 1=Solid.
     -- @param #table Color RGB color table {r, g, b}, e.g. {1,0,0} for red (default).
     -- @param #number Alpha Transparency [0,1]. Default 1.
-    -- @param #table FillColor RGB color table {r, g, b}, e.g. {1,0,0} for red (default).
-    -- @param #number FillAlpha Transparency [0,1]. Default 0.5.
+    -- @param #table FillColor RGB color table {r, g, b}, e.g. {1,0,0} for red. Default is same as `Color` value.
+    -- @param #number FillAlpha Transparency [0,1]. Default 0.15.
+    -- @param #number LineType Line type: 0=No line, 1=Solid, 2=Dashed, 3=Dotted, 4=Dot dash, 5=Long dash, 6=Two dash. Default 1=Solid.
     -- @param #boolean ReadOnly (Optional) Mark is readonly and cannot be removed by users. Default false.
     -- @param #string Text (Optional) Text displayed when mark is added. Default none.
-    -- @return #number The resulting Mark ID which is a number.
-    function COORDINATE:CircleToAll(Radius, Coalition, LineType, Color, Alpha, FillColor, FillAlpha, ReadOnly, Text)
+    -- @return #number The resulting Mark ID, which is a number. Can be used to remove the object again. 
+    function COORDINATE:CircleToAll(Radius, Coalition, Color, Alpha, FillColor, FillAlpha, LineType, ReadOnly, Text)
       local MarkID = UTILS.GetMarkID()
       if ReadOnly==nil then
         ReadOnly=false
@@ -2029,14 +2037,188 @@ do -- COORDINATE
       Color=Color or {1,0,0}
       Color[4]=Alpha or 1.0
       LineType=LineType or 1
-      FillColor=FillColor or {1,0,0}
-      FillColor[4]=FillAlpha or 0.5
+      FillColor=FillColor or Color
+      FillColor[4]=FillAlpha or 0.15
       trigger.action.circleToAll(Coalition, MarkID, vec3, Radius, Color, FillColor, LineType, ReadOnly, Text or "")
       return MarkID
     end            
   
   end -- Markings
-  
+
+    --- Rectangle to all. Creates a rectangle on the map from the COORDINATE in one corner to the end COORDINATE in the opposite corner.
+    -- Creates a line on the F10 map from one point to another.
+    -- @param #COORDINATE self
+    -- @param #COORDINATE Endpoint COORDIANTE in the opposite corner.
+    -- @param #number Coalition Coalition: All=-1, Neutral=0, Red=1, Blue=2. Default -1=All.
+    -- @param #table Color RGB color table {r, g, b}, e.g. {1,0,0} for red (default).
+    -- @param #number Alpha Transparency [0,1]. Default 1.
+    -- @param #table FillColor RGB color table {r, g, b}, e.g. {1,0,0} for red. Default is same as `Color` value.
+    -- @param #number FillAlpha Transparency [0,1]. Default 0.15.
+    -- @param #number LineType Line type: 0=No line, 1=Solid, 2=Dashed, 3=Dotted, 4=Dot dash, 5=Long dash, 6=Two dash. Default 1=Solid.    
+    -- @param #boolean ReadOnly (Optional) Mark is readonly and cannot be removed by users. Default false.
+    -- @param #string Text (Optional) Text displayed when mark is added. Default none.
+    -- @return #number The resulting Mark ID, which is a number. Can be used to remove the object again. 
+    function COORDINATE:RectToAll(Endpoint, Coalition, Color, Alpha, FillColor, FillAlpha, LineType, ReadOnly, Text)
+      local MarkID = UTILS.GetMarkID()
+      if ReadOnly==nil then
+        ReadOnly=false
+      end
+      local vec3=Endpoint:GetVec3()
+      Coalition=Coalition or -1
+      Color=Color or {1,0,0}
+      Color[4]=Alpha or 1.0
+      LineType=LineType or 1
+      FillColor=FillColor or Color
+      FillColor[4]=FillAlpha or 0.15      
+      trigger.action.rectToAll(Coalition, MarkID, self:GetVec3(), vec3, Color, FillColor, LineType, ReadOnly, Text or "")
+      return MarkID
+    end
+    
+    --- Creates a shape defined by 4 points on the F10 map. The first point is the current COORDINATE. The remaining three points need to be specified.
+    -- @param #COORDINATE self
+    -- @param #COORDINATE Coord2 Second COORDIANTE of the quad shape.
+    -- @param #COORDINATE Coord3 Third COORDIANTE of the quad shape.
+    -- @param #COORDINATE Coord4 Fourth COORDIANTE of the quad shape.
+    -- @param #number Coalition Coalition: All=-1, Neutral=0, Red=1, Blue=2. Default -1=All.
+    -- @param #table Color RGB color table {r, g, b}, e.g. {1,0,0} for red (default).
+    -- @param #number Alpha Transparency [0,1]. Default 1.
+    -- @param #table FillColor RGB color table {r, g, b}, e.g. {1,0,0} for red. Default is same as `Color` value.
+    -- @param #number FillAlpha Transparency [0,1]. Default 0.15.
+    -- @param #number LineType Line type: 0=No line, 1=Solid, 2=Dashed, 3=Dotted, 4=Dot dash, 5=Long dash, 6=Two dash. Default 1=Solid.    
+    -- @param #boolean ReadOnly (Optional) Mark is readonly and cannot be removed by users. Default false.
+    -- @param #string Text (Optional) Text displayed when mark is added. Default none.
+    -- @return #number The resulting Mark ID, which is a number. Can be used to remove the object again. 
+    function COORDINATE:QuadToAll(Coord2, Coord3, Coord4, Coalition, Color, Alpha, FillColor, FillAlpha, LineType, ReadOnly, Text)
+      local MarkID = UTILS.GetMarkID()
+      if ReadOnly==nil then
+        ReadOnly=false
+      end
+      local point1=self:GetVec3()
+      local point2=Coord2:GetVec3()
+      local point3=Coord3:GetVec3()
+      local point4=Coord4:GetVec3()
+      Coalition=Coalition or -1
+      Color=Color or {1,0,0}
+      Color[4]=Alpha or 1.0
+      LineType=LineType or 1
+      FillColor=FillColor or Color
+      FillColor[4]=FillAlpha or 0.15
+      trigger.action.quadToAll(Coalition, MarkID, self:GetVec3(), point2, point3, point4, Color, FillColor, LineType, ReadOnly, Text or "")
+      return MarkID
+    end
+    
+    --- Creates a free form shape on the F10 map. The first point is the current COORDINATE. The remaining points need to be specified.
+    -- **NOTE**: A free form polygon must have **at least three points** in total and currently only **up to 10 points** in total are supported.
+    -- @param #COORDINATE self
+    -- @param #table Coordinates Table of coordinates of the remaining points of the shape.
+    -- @param #number Coalition Coalition: All=-1, Neutral=0, Red=1, Blue=2. Default -1=All.
+    -- @param #table Color RGB color table {r, g, b}, e.g. {1,0,0} for red (default).
+    -- @param #number Alpha Transparency [0,1]. Default 1.
+    -- @param #table FillColor RGB color table {r, g, b}, e.g. {1,0,0} for red. Default is same as `Color` value.
+    -- @param #number FillAlpha Transparency [0,1]. Default 0.15.
+    -- @param #number LineType Line type: 0=No line, 1=Solid, 2=Dashed, 3=Dotted, 4=Dot dash, 5=Long dash, 6=Two dash. Default 1=Solid.    
+    -- @param #boolean ReadOnly (Optional) Mark is readonly and cannot be removed by users. Default false.
+    -- @param #string Text (Optional) Text displayed when mark is added. Default none.
+    -- @return #number The resulting Mark ID, which is a number. Can be used to remove the object again. 
+    function COORDINATE:MarkupToAllFreeForm(Coordinates, Coalition, Color, Alpha, FillColor, FillAlpha, LineType, ReadOnly, Text)
+      local MarkID = UTILS.GetMarkID()
+      if ReadOnly==nil then
+        ReadOnly=false
+      end
+      Coalition=Coalition or -1
+      Color=Color or {1,0,0}
+      Color[4]=Alpha or 1.0
+      LineType=LineType or 1
+      FillColor=FillColor or Color
+      FillColor[4]=FillAlpha or 0.15
+      
+      local vecs={}
+      table.insert(vecs, self:GetVec3())
+      for _,coord in ipairs(Coordinates) do
+        table.insert(vecs, coord:GetVec3())
+      end
+      
+      if #vecs<3 then
+        self:E("ERROR: A free form polygon needs at least three points!")
+      elseif #vecs==3 then
+        trigger.action.markupToAll(7, Coalition, MarkID, vecs[1], vecs[2], vecs[3], Color, FillColor, LineType, ReadOnly, Text or "")
+      elseif #vecs==4 then
+        trigger.action.markupToAll(7, Coalition, MarkID, vecs[1], vecs[2], vecs[3], vecs[4], Color, FillColor, LineType, ReadOnly, Text or "")
+      elseif #vecs==5 then
+        trigger.action.markupToAll(7, Coalition, MarkID, vecs[1], vecs[2], vecs[3], vecs[4], vecs[5], Color, FillColor, LineType, ReadOnly, Text or "")
+      elseif #vecs==6 then
+        trigger.action.markupToAll(7, Coalition, MarkID, vecs[1], vecs[2], vecs[3], vecs[4], vecs[5], vecs[6], Color, FillColor, LineType, ReadOnly, Text or "")        
+      elseif #vecs==7 then
+        trigger.action.markupToAll(7, Coalition, MarkID, vecs[1], vecs[2], vecs[3], vecs[4], vecs[5], vecs[6], vecs[7], Color, FillColor, LineType, ReadOnly, Text or "")
+      elseif #vecs==8 then
+        trigger.action.markupToAll(7, Coalition, MarkID, vecs[1], vecs[2], vecs[3], vecs[4], vecs[5], vecs[6], vecs[7], vecs[8], Color, FillColor, LineType, ReadOnly, Text or "")
+      elseif #vecs==9 then
+        trigger.action.markupToAll(7, Coalition, MarkID, vecs[1], vecs[2], vecs[3], vecs[4], vecs[5], vecs[6], vecs[7], vecs[8], vecs[9], Color, FillColor, LineType, ReadOnly, Text or "")
+      elseif #vecs==10 then
+        trigger.action.markupToAll(7, Coalition, MarkID, vecs[1], vecs[2], vecs[3], vecs[4], vecs[5], vecs[6], vecs[7], vecs[8], vecs[9], vecs[10], Color, FillColor, LineType, ReadOnly, Text or "")                
+      else
+        self:E("ERROR: Currently a free form polygon can only have 10 points in total!")
+        -- Unfortunately, unpack(vecs) does not work! So no idea how to generalize this :(
+        trigger.action.markupToAll(7, Coalition, MarkID, unpack(vecs), Color, FillColor, LineType, ReadOnly, Text or "")
+      end
+      
+      return MarkID
+    end    
+    
+    --- Text to all. Creates a text imposed on the map at the COORDINATE. Text scales with the map.
+    -- @param #COORDINATE self
+    -- @param #string Text Text displayed on the F10 map.
+    -- @param #number Coalition Coalition: All=-1, Neutral=0, Red=1, Blue=2. Default -1=All.
+    -- @param #table Color RGB color table {r, g, b}, e.g. {1,0,0} for red (default).
+    -- @param #number Alpha Transparency [0,1]. Default 1.
+    -- @param #table FillColor RGB color table {r, g, b}, e.g. {1,0,0} for red. Default is same as `Color` value.
+    -- @param #number FillAlpha Transparency [0,1]. Default 0.15.
+    -- @param #number FontSize Font size.    
+    -- @param #boolean ReadOnly (Optional) Mark is readonly and cannot be removed by users. Default false.
+    -- @return #number The resulting Mark ID, which is a number. Can be used to remove the object again. 
+    function COORDINATE:TextToAll(Text, Coalition, Color, Alpha, FillColor, FillAlpha, FontSize, ReadOnly)
+      local MarkID = UTILS.GetMarkID()
+      if ReadOnly==nil then
+        ReadOnly=false
+      end
+      Coalition=Coalition or -1
+      Color=Color or {1,0,0}
+      Color[4]=Alpha or 1.0
+      FillColor=FillColor or Color
+      FillColor[4]=FillAlpha or 0.15      
+      FontSize=FontSize or 12
+      trigger.action.textToAll(Coalition, MarkID, self:GetVec3(), Color, FillColor, FontSize, ReadOnly, Text or "Hello World")
+      return MarkID
+    end
+    
+    --- Arrow to all. Creates an arrow from the COORDINATE to the endpoint COORDINATE on the F10 map. There is no control over other dimensions of the arrow.
+    -- @param #COORDINATE self
+    -- @param #COORDINATE Endpoint COORDINATE where the tip of the arrow is pointing at.
+    -- @param #number Coalition Coalition: All=-1, Neutral=0, Red=1, Blue=2. Default -1=All.
+    -- @param #table Color RGB color table {r, g, b}, e.g. {1,0,0} for red (default).
+    -- @param #number Alpha Transparency [0,1]. Default 1.
+    -- @param #table FillColor RGB color table {r, g, b}, e.g. {1,0,0} for red. Default is same as `Color` value.
+    -- @param #number FillAlpha Transparency [0,1]. Default 0.15.
+    -- @param #number LineType Line type: 0=No line, 1=Solid, 2=Dashed, 3=Dotted, 4=Dot dash, 5=Long dash, 6=Two dash. Default 1=Solid.
+    -- @param #boolean ReadOnly (Optional) Mark is readonly and cannot be removed by users. Default false.
+    -- @param #string Text (Optional) Text displayed when mark is added. Default none.
+    -- @return #number The resulting Mark ID, which is a number. Can be used to remove the object again. 
+    function COORDINATE:ArrowToAll(Endpoint, Coalition, Color, Alpha, FillColor, FillAlpha, LineType, ReadOnly, Text)
+      local MarkID = UTILS.GetMarkID()
+      if ReadOnly==nil then
+        ReadOnly=false
+      end
+      local vec3=Endpoint:GetVec3()
+      Coalition=Coalition or -1
+      Color=Color or {1,0,0}
+      Color[4]=Alpha or 1.0
+      LineType=LineType or 1
+      FillColor=FillColor or Color
+      FillColor[4]=FillAlpha or 0.15
+      --trigger.action.textToAll(Coalition, MarkID, self:GetVec3(), Color, FillColor, FontSize, ReadOnly, Text or "Hello World")
+      trigger.action.arrowToAll(Coalition, MarkID, vec3, self:GetVec3(), Color, FillColor, LineType, ReadOnly, Text or "")      
+      return MarkID
+    end                
 
   --- Returns if a Coordinate has Line of Sight (LOS) with the ToCoordinate.
   -- @param #COORDINATE self

--- a/Moose Development/Moose/Core/Zone.lua
+++ b/Moose Development/Moose/Core/Zone.lua
@@ -17,6 +17,7 @@
 --   * Get zone properties.
 --   * Get zone bounding box.
 --   * Set/get zone name.
+--   * Draw zones (circular and polygon) on the F10 map.
 --   
 -- 
 -- There are essentially two core functions that zones accomodate:
@@ -494,6 +495,10 @@ end
 --   * @{#ZONE_RADIUS.GetRandomVec2}(): Gets a random 2D point in the zone.
 --   * @{#ZONE_RADIUS.GetRandomPointVec2}(): Gets a @{Core.Point#POINT_VEC2} object representing a random 2D point in the zone.
 --   * @{#ZONE_RADIUS.GetRandomPointVec3}(): Gets a @{Core.Point#POINT_VEC3} object representing a random 3D point in the zone. Note that the height of the point is at landheight.
+-- 
+-- ## Draw zone
+-- 
+--   * @{#ZONE_RADIUS.DrawZone}(): Draws the zone on the F10 map.
 -- 
 -- @field #ZONE_RADIUS
 ZONE_RADIUS = {
@@ -1506,6 +1511,11 @@ end
 --   * @{#ZONE_POLYGON_BASE.GetRandomVec2}(): Gets a random 2D point in the zone.
 --   * @{#ZONE_POLYGON_BASE.GetRandomPointVec2}(): Return a @{Core.Point#POINT_VEC2} object representing a random 2D point within the zone.
 --   * @{#ZONE_POLYGON_BASE.GetRandomPointVec3}(): Return a @{Core.Point#POINT_VEC3} object representing a random 3D point at landheight within the zone.
+--
+-- ## Draw zone
+-- 
+--   * @{#ZONE_POLYGON_BASE.DrawZone}(): Draws the zone on the F10 map.
+--
 -- 
 -- @field #ZONE_POLYGON_BASE
 ZONE_POLYGON_BASE = {
@@ -1938,7 +1948,7 @@ end
 -- This is especially handy if you want to quickly setup a SET_ZONE...
 -- So when you would declare `local SetZone = SET_ZONE:New():FilterPrefixes( "Defense" ):FilterStart()`,
 -- then SetZone would contain the ZONE_POLYGON object `DefenseZone` as part of the zone collection,
--- without much scripting overhead!!! 
+-- without much scripting overhead!
 -- 
 -- @field #ZONE_POLYGON
 ZONE_POLYGON = {

--- a/Moose Development/Moose/DCS.lua
+++ b/Moose Development/Moose/DCS.lua
@@ -295,6 +295,17 @@ do -- country
   -- @field QATAR
   -- @field OMAN
   -- @field UNITED_ARAB_EMIRATES
+  -- @field SOUTH_AFRICA
+  -- @field CUBA
+  -- @field PORTUGAL
+  -- @field GDR
+  -- @field LEBANON
+  -- @field CJTF_BLUE
+  -- @field CJTF_RED
+  -- @field UN_PEACEKEEPERS
+  -- @field Argentinia
+  -- @field Cyprus
+  -- @field Slovenia
 
   country = {} --#country
 

--- a/Moose Development/Moose/Modules.lua
+++ b/Moose Development/Moose/Modules.lua
@@ -2,6 +2,7 @@ __Moose.Include( 'Scripts/Moose/Utilities/Enums.lua' )
 __Moose.Include( 'Scripts/Moose/Utilities/Routines.lua' )
 __Moose.Include( 'Scripts/Moose/Utilities/Utils.lua' )
 __Moose.Include( 'Scripts/Moose/Utilities/Profiler.lua' )
+__Moose.Include( 'Scripts/Moose/Utilities/Templates.lua' )
 
 __Moose.Include( 'Scripts/Moose/Core/Base.lua' )
 __Moose.Include( 'Scripts/Moose/Core/UserFlag.lua' )

--- a/Moose Development/Moose/Utilities/Templates.lua
+++ b/Moose Development/Moose/Utilities/Templates.lua
@@ -1,0 +1,183 @@
+--- **Utils** Templates
+-- 
+-- DCS unit templates
+-- 
+-- @module Utilities.Templates
+-- @image MOOSE.JPG
+
+--- TEMPLATE class.
+-- @type TEMPLATE
+-- @field #string ClassName Name of the class.
+
+--- *Templates*
+--
+-- ===
+--
+-- ![Banner Image](..\Presentations\Utilities\PROFILER_Main.jpg)
+--
+-- Get DCS templates from thin air.
+-- 
+-- # Ground Units
+-- 
+-- Ground units.
+-- 
+-- # Naval Units
+-- 
+-- Ships are not implemented yet.
+-- 
+-- # Aircraft
+-- 
+-- ## Airplanes
+-- 
+-- Airplanes are not implemented yet.
+-- 
+-- ## Helicopters
+-- 
+-- Helicopters are not implemented yet.
+-- 
+-- @field #TEMPLATE
+TEMPLATE = {
+  ClassName      = "TEMPLATE",
+  Ground         = {},
+  Naval          = {},
+  Airplane       = {},
+  Helicopter     = {},
+}
+
+--- Pattern steps.
+-- @type TEMPLATE.Ground
+-- @param #string InfantryAK
+TEMPLATE.Ground={
+  InfantryAK="Infantry AK",
+  ParatrooperAKS74="Paratrooper AKS-74",
+  ParatrooperRPG16="Paratrooper RPG-16",
+  SoldierWWIIUS="soldier_wwii_us",
+  InfantryM248="Infantry M249",
+  SoldierM4="Soldier M4",
+}
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Start/Stop Profiler
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+--- Get template for ground units.
+-- @param #string TypeName Type name of the unit(s) in the groups. See `TEMPLATE.Ground`.
+-- @param #string GroupName Name of the spawned group. **Must be unique!**
+-- @param #number CountryID Country ID. Default `country.id.USA`. Coalition is automatically determined by the one the country belongs to.
+-- @param DCS#Vec3 Vec3 Position of the group.
+-- @param #number Nunits Number of units. Default 1.
+-- @param #number Radius Spawn radius for additonal units in meters. Default 50 m.
+-- @return #table Template Template table.
+function TEMPLATE.GetGround(TypeName, GroupName, CountryID, Vec3, Nunits, Radius)
+
+  local template=UTILS.DeepCopy(TEMPLATE.GenericGround)
+  
+  template.name=GroupName or "Ground-1"
+  
+  -- These are additional entries required by the MOOSE _DATABASE:Spawn() function.
+  template.CountryID=country.id.USA
+  template.CoalitionID=coalition.getCountryCoalition(template.CountryID)
+  template.CategoryID=Unit.Category.GROUND_UNIT
+  
+  template.units[1].type=TypeName or "Infantry AK"
+  template.units[1].name=GroupName.."-1"
+  
+  if Vec3 then
+    TEMPLATE.SetPositionFromVec3(template, Vec3)
+  end
+
+  return template
+end
+
+TEMPLATE.GenericGround=
+{
+  ["visible"] = false,
+  ["tasks"] = {}, -- end of ["tasks"]
+  ["uncontrollable"] = false,
+  ["task"] = "Ground Nothing",
+  ["route"] = 
+  {
+      ["spans"] = {}, -- end of ["spans"]
+      ["points"] = 
+      {
+          [1] = 
+          {
+              ["alt"] = 0,
+              ["type"] = "Turning Point",
+              ["ETA"] = 0,
+              ["alt_type"] = "BARO",
+              ["formation_template"] = "",
+              ["y"] = 0,
+              ["x"] = 0,
+              ["ETA_locked"] = true,
+              ["speed"] = 0,
+              ["action"] = "Off Road",
+              ["task"] = 
+              {
+                  ["id"] = "ComboTask",
+                  ["params"] = 
+                  {
+                      ["tasks"] = 
+                      {
+                      }, -- end of ["tasks"]
+                  }, -- end of ["params"]
+              }, -- end of ["task"]
+              ["speed_locked"] = true,
+          }, -- end of [1]
+      }, -- end of ["points"]
+  }, -- end of ["route"]
+  ["groupId"] = nil,
+  ["hidden"] = false,
+  ["units"] = 
+  {
+      [1] = 
+      {
+          ["transportable"] = 
+          {
+              ["randomTransportable"] = false,
+          }, -- end of ["transportable"]
+          ["skill"] = "Average",
+          ["type"] = "Infantry AK",
+          ["unitId"] = nil,
+          ["y"] = 0,
+          ["x"] = 0,
+          ["name"] = "Infantry AK-47 Rus",
+          ["heading"] = 0,
+          ["playerCanDrive"] = false,
+      }, -- end of [1]
+  }, -- end of ["units"]
+  ["y"] = 0,
+  ["x"] = 0,
+  ["name"] = "Infantry AK-47 Rus",
+  ["start_time"] = 0,
+}
+
+--- Set the position of the template.
+-- @param #table Template The template to be modified.
+-- @param DCS#Vec2 Vec2 2D Position vector with x and y components of the group.
+function TEMPLATE.SetPositionFromVec2(Template, Vec2)
+
+  Template.x=Vec2.x
+  Template.y=Vec2.y
+  
+  for _,unit in pairs(Template.units) do
+    unit.x=Vec2.x
+    unit.y=Vec2.y
+  end
+  
+  Template.route.points[1].x=Vec2.x
+  Template.route.points[1].y=Vec2.y
+  Template.route.points[1].alt=0 --TODO: Use land height.
+ 
+end
+
+--- Set the position of the template.
+-- @param #table Template The template to be modified.
+-- @param DCS#Vec3 Vec3 Position vector of the group.
+function TEMPLATE.SetPositionFromVec3(Template, Vec3)
+
+  local Vec2={x=Vec3.x, y=Vec3.z}
+  
+  TEMPLATE.SetPositionFromVec2(Template, Vec2)
+  
+end

--- a/Moose Development/Moose/Utilities/Templates.lua
+++ b/Moose Development/Moose/Utilities/Templates.lua
@@ -44,10 +44,10 @@ TEMPLATE = {
   Helicopter     = {},
 }
 
---- Pattern steps.
--- @type TEMPLATE.Ground
+--- Ground unit type names.
+-- @type TEMPLATE.TypeGround
 -- @param #string InfantryAK
-TEMPLATE.Ground={
+TEMPLATE.TypeGround={
   InfantryAK="Infantry AK",
   ParatrooperAKS74="Paratrooper AKS-74",
   ParatrooperRPG16="Paratrooper RPG-16",
@@ -56,40 +56,227 @@ TEMPLATE.Ground={
   SoldierM4="Soldier M4",
 }
 
+--- Naval unit type names.
+-- @type TEMPLATE.TypeNaval
+-- @param #string Ticonderoga
+TEMPLATE.TypeNaval={
+  Ticonderoga="TICONDEROG",
+}
+
+--- Rotary wing unit type names.
+-- @type TEMPLATE.TypeAirplane
+-- @param #string A10C
+TEMPLATE.TypeAirplane={
+  A10C="A-10C",
+}
+
+--- Rotary wing unit type names.
+-- @type TEMPLATE.TypeHelicopter
+-- @param #string AH1W
+TEMPLATE.TypeHelicopter={
+  AH1W="AH-1W",
+}
+
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--- Start/Stop Profiler
+-- Ground Template
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 --- Get template for ground units.
 -- @param #string TypeName Type name of the unit(s) in the groups. See `TEMPLATE.Ground`.
 -- @param #string GroupName Name of the spawned group. **Must be unique!**
 -- @param #number CountryID Country ID. Default `country.id.USA`. Coalition is automatically determined by the one the country belongs to.
--- @param DCS#Vec3 Vec3 Position of the group.
+-- @param DCS#Vec3 Vec3 Position of the group and the first unit.
 -- @param #number Nunits Number of units. Default 1.
 -- @param #number Radius Spawn radius for additonal units in meters. Default 50 m.
 -- @return #table Template Template table.
 function TEMPLATE.GetGround(TypeName, GroupName, CountryID, Vec3, Nunits, Radius)
 
+  -- Defaults.
+  TypeName=TypeName or TEMPLATE.TypeGround.SoldierM4
+  GroupName=GroupName or "Ground-1"
+  CountryID=CountryID or country.id.USA
+  Vec3=Vec3 or {x=0, y=0, z=0}
+  Nunits=Nunits or 1
+  Radius=Radius or 50
+
+
+  -- Get generic template.
   local template=UTILS.DeepCopy(TEMPLATE.GenericGround)
-  
-  template.name=GroupName or "Ground-1"
+
+  -- Set group name.
+  template.name=GroupName
   
   -- These are additional entries required by the MOOSE _DATABASE:Spawn() function.
-  template.CountryID=country.id.USA
+  template.CountryID=CountryID
   template.CoalitionID=coalition.getCountryCoalition(template.CountryID)
   template.CategoryID=Unit.Category.GROUND_UNIT
   
-  template.units[1].type=TypeName or "Infantry AK"
-  template.units[1].name=GroupName.."-1"
+  -- Set first unit.
+  template.units[1].type=TypeName
+  template.units[1].name=GroupName.."-1"  
   
   if Vec3 then
     TEMPLATE.SetPositionFromVec3(template, Vec3)
   end
+  
+  TEMPLATE.SetUnits(template, Nunits, COORDINATE:NewFromVec3(Vec3), Radius)
+
+  return template
+end
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Naval Template
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+--- Get template for ground units.
+-- @param #string TypeName Type name of the unit(s) in the groups. See `TEMPLATE.Ground`.
+-- @param #string GroupName Name of the spawned group. **Must be unique!**
+-- @param #number CountryID Country ID. Default `country.id.USA`. Coalition is automatically determined by the one the country belongs to.
+-- @param DCS#Vec3 Vec3 Position of the group and the first unit.
+-- @param #number Nunits Number of units. Default 1.
+-- @param #number Radius Spawn radius for additonal units in meters. Default 500 m.
+-- @return #table Template Template table.
+function TEMPLATE.GetNaval(TypeName, GroupName, CountryID, Vec3, Nunits, Radius)
+
+  -- Defaults.
+  TypeName=TypeName or TEMPLATE.TypeNaval.Ticonderoga
+  GroupName=GroupName or "Naval-1"
+  CountryID=CountryID or country.id.USA
+  Vec3=Vec3 or {x=0, y=0, z=0}
+  Nunits=Nunits or 1
+  Radius=Radius or 500
+
+
+  -- Get generic template.
+  local template=UTILS.DeepCopy(TEMPLATE.GenericNaval)
+
+  -- Set group name.
+  template.name=GroupName
+  
+  -- These are additional entries required by the MOOSE _DATABASE:Spawn() function.
+  template.CountryID=CountryID
+  template.CoalitionID=coalition.getCountryCoalition(template.CountryID)
+  template.CategoryID=Unit.Category.SHIP
+  
+  -- Set first unit.
+  template.units[1].type=TypeName
+  template.units[1].name=GroupName.."-1"  
+  
+  if Vec3 then
+    TEMPLATE.SetPositionFromVec3(template, Vec3)
+  end
+  
+  TEMPLATE.SetUnits(template, Nunits, COORDINATE:NewFromVec3(Vec3), Radius)
+
+  return template
+end
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Aircraft Template
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+--- Get template for fixed wing units.
+-- @param #string TypeName Type name of the unit(s) in the groups. See `TEMPLATE.Ground`.
+-- @param #string GroupName Name of the spawned group. **Must be unique!**
+-- @param #number CountryID Country ID. Default `country.id.USA`. Coalition is automatically determined by the one the country belongs to.
+-- @param DCS#Vec3 Vec3 Position of the group and the first unit.
+-- @param #number Nunits Number of units. Default 1.
+-- @param #number Radius Spawn radius for additonal units in meters. Default 500 m.
+-- @return #table Template Template table.
+function TEMPLATE.GetAirplane(TypeName, GroupName, CountryID, Vec3, Nunits, Radius)
+
+  -- Defaults.
+  TypeName=TypeName or TEMPLATE.TypeAirplane.A10C
+  GroupName=GroupName or "Airplane-1"
+  CountryID=CountryID or country.id.USA
+  Vec3=Vec3 or {x=0, y=1000, z=0}
+  Nunits=Nunits or 1
+  Radius=Radius or 100
+
+  local template=TEMPLATE._GetAircraft(true, TypeName, GroupName, CountryID, Vec3, Nunits, Radius)
+
+  return template
+end
+
+--- Get template for fixed wing units.
+-- @param #string TypeName Type name of the unit(s) in the groups. See `TEMPLATE.Ground`.
+-- @param #string GroupName Name of the spawned group. **Must be unique!**
+-- @param #number CountryID Country ID. Default `country.id.USA`. Coalition is automatically determined by the one the country belongs to.
+-- @param DCS#Vec3 Vec3 Position of the group and the first unit.
+-- @param #number Nunits Number of units. Default 1.
+-- @param #number Radius Spawn radius for additonal units in meters. Default 500 m.
+-- @return #table Template Template table.
+function TEMPLATE.GetHelicopter(TypeName, GroupName, CountryID, Vec3, Nunits, Radius)
+
+  -- Defaults.
+  TypeName=TypeName or TEMPLATE.TypeHelicopter.AH1W
+  GroupName=GroupName or "Helicopter-1"
+  CountryID=CountryID or country.id.USA
+  Vec3=Vec3 or {x=0, y=500, z=0}
+  Nunits=Nunits or 1
+  Radius=Radius or 100
+
+  -- Limit unis to 4.
+  Nunits=math.min(Nunits, 4)
+
+  local template=TEMPLATE._GetAircraft(false, TypeName, GroupName, CountryID, Vec3, Nunits, Radius)
 
   return template
 end
 
 
+--- Get template for aircraft units.
+-- @param #boolean Airplane If true, this is a fixed wing. Else, rotary wing.
+-- @param #string TypeName Type name of the unit(s) in the groups. See `TEMPLATE.Ground`.
+-- @param #string GroupName Name of the spawned group. **Must be unique!**
+-- @param #number CountryID Country ID. Default `country.id.USA`. Coalition is automatically determined by the one the country belongs to.
+-- @param DCS#Vec3 Vec3 Position of the group and the first unit.
+-- @param #number Nunits Number of units. Default 1.
+-- @param #number Radius Spawn radius for additonal units in meters. Default 500 m.
+-- @return #table Template Template table.
+function TEMPLATE._GetAircraft(Airplane, TypeName, GroupName, CountryID, Vec3, Nunits, Radius)
+
+  -- Defaults.
+  TypeName=TypeName
+  GroupName=GroupName or "Aircraft-1"
+  CountryID=CountryID or country.id.USA
+  Vec3=Vec3 or {x=0, y=0, z=0}
+  Nunits=Nunits or 1
+  Radius=Radius or 100
+
+  -- Get generic template.
+  local template=UTILS.DeepCopy(TEMPLATE.GenericAircraft)
+
+  -- Set group name.
+  template.name=GroupName
+  
+  -- These are additional entries required by the MOOSE _DATABASE:Spawn() function.
+  template.CountryID=CountryID
+  template.CoalitionID=coalition.getCountryCoalition(template.CountryID)
+  if Airplane then
+    template.CategoryID=Unit.Category.AIRPLANE
+  else
+    template.CategoryID=Unit.Category.HELICOPTER
+  end
+  
+  -- Set first unit.
+  template.units[1].type=TypeName
+  template.units[1].name=GroupName.."-1"  
+  
+  -- Set position.
+  if Vec3 then
+    TEMPLATE.SetPositionFromVec3(template, Vec3)
+  end
+  
+  -- Set number of units.
+  TEMPLATE.SetUnits(template, Nunits, COORDINATE:NewFromVec3(Vec3), Radius)
+
+  return template
+end
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Misc Functions
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 --- Set the position of the template.
 -- @param #table Template The template to be modified.
@@ -119,6 +306,84 @@ function TEMPLATE.SetPositionFromVec3(Template, Vec3)
   
   TEMPLATE.SetPositionFromVec2(Template, Vec2)
   
+end
+
+--- Set the position of the template.
+-- @param #table Template The template to be modified.
+-- @param #number N Total number of units in the group. 
+-- @param Core.Point#COORDINATE Coordinate Position of the first unit.
+-- @param #number Radius Radius in meters to randomly place the additional units.
+function TEMPLATE.SetUnits(Template, N, Coordinate, Radius)
+
+  local units=Template.units
+  
+  local unit1=units[1]
+  
+  local Vec3=Coordinate:GetVec3()
+  
+  unit1.x=Vec3.x
+  unit1.y=Vec3.z
+  unit1.alt=Vec3.y
+  
+  for i=2,N do  
+    units[i]=UTILS.DeepCopy(unit1)
+  end
+  
+  for i=1,N do
+    local unit=units[i]
+    unit.name=string.format("%s-%d", Template.name, i)
+    if i>1 then
+      local vec2=Coordinate:GetRandomCoordinateInRadius(Radius, 5):GetVec2()
+      unit.x=vec2.x
+      unit.y=vec2.y
+      unit.alt=unit1.alt
+    end
+  end
+
+end
+
+--- Set the position of the template.
+-- @param #table Template The template to be modified.
+-- @param Wrapper.Airbase#AIRBASE AirBase The airbase where the aircraft are spawned.
+-- @param #table ParkingSpots List of parking spot IDs. Every unit needs one!
+-- @param #boolean EngineOn If true, aircraft are spawned hot.
+function TEMPLATE.SetAirbase(Template, AirBase, ParkingSpots, EngineOn)
+
+  -- Airbase ID.
+  local AirbaseID=AirBase:GetID()
+
+  -- Spawn point.
+  local point=Template.route.points[1]
+    
+  -- Set ID.
+  if AirBase:IsAirdrome() then
+    point.airdromeId=AirbaseID
+  else
+    point.helipadId=AirbaseID
+    point.linkUnit=AirbaseID
+  end
+  
+  if EngineOn then
+    point.action=COORDINATE.WaypointAction.FromParkingAreaHot
+    point.type=COORDINATE.WaypointType.TakeOffParkingHot
+  else
+    point.action=COORDINATE.WaypointAction.FromParkingArea
+    point.type=COORDINATE.WaypointType.TakeOffParking
+  end
+  
+  for i,unit in ipairs(Template.units) do
+    unit.parking_id=ParkingSpots[i]
+  end
+  
+end
+
+--- Add a waypoint.
+-- @param #table Template The template to be modified.
+-- @param #table Waypoint Waypoint table.
+function TEMPLATE.AddWaypoint(Template, Waypoint)
+
+  table.insert(Template.route.points, Waypoint)
+
 end
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -255,79 +520,82 @@ TEMPLATE.GenericNaval=
 }
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--- Generic Ship Template
+-- Generic Aircraft Template
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-TEMPLATE.GenericHelicopter=
+TEMPLATE.GenericAircraft=
 {
-  ["modulation"] = 0,
-  ["tasks"] = {}, -- end of ["tasks"]
-  ["radioSet"] = false,
-  ["task"] = "Nothing",
+  ["groupId"] = nil,
+  ["name"] = "Rotary-1",
   ["uncontrolled"] = false,
-  ["taskSelected"] = true,
+  ["hidden"] = false,
+  ["task"] = "Nothing",
+  ["y"] = 0,
+  ["x"] = 0,
+  ["start_time"] = 0,
+  ["communication"] = true,   
+  ["radioSet"] = false,
+  ["frequency"] = 127.5,
+  ["modulation"] = 0,  
+  ["taskSelected"] = true,  
+  ["tasks"] = {}, -- end of ["tasks"]
   ["route"] = 
   {
       ["points"] = 
       {
           [1] = 
           {
-              ["alt"] = 10,
-              ["action"] = "From Parking Area",
-              ["alt_type"] = "BARO",
-              ["speed"] = 41.666666666667,
+              ["y"] = 0,
+              ["x"] = 0,
+              ["alt"] = 1000,
+              ["alt_type"] = "BARO",              
+              ["action"] = "Turning Point",
+              ["type"] = "Turning Point",              
+              ["airdromeId"] = nil,
               ["task"] = 
               {
                   ["id"] = "ComboTask",
                   ["params"] = 
                   {
-                      ["tasks"] = 
-                      {
-                      }, -- end of ["tasks"]
+                      ["tasks"] = {}, -- end of ["tasks"]
                   }, -- end of ["params"]
               }, -- end of ["task"]
-              ["type"] = "TakeOffParking",
               ["ETA"] = 0,
               ["ETA_locked"] = true,
-              ["y"] = 618351.087765,
-              ["x"] = -356168.27327001,
+              ["speed"] = 100,
+              ["speed_locked"] = true,              
               ["formation_template"] = "",
-              ["airdromeId"] = 22,
-              ["speed_locked"] = true,
           }, -- end of [1]
       }, -- end of ["points"]
   }, -- end of ["route"]
-  ["groupId"] = nil,
-  ["hidden"] = false,
   ["units"] = 
   {
       [1] = 
       {
-          ["alt"] = 10,
-          ["alt_type"] = "BARO",
+          ["name"] = "Rotary-1-1",
+          ["unitId"] = nil,    
+          ["type"] = "AH-1W",
+          ["onboard_num"] = "050",
           ["livery_id"] = "USA X Black",
           ["skill"] = "High",
-          ["parking"] = "4",
           ["ropeLength"] = 15,
-          ["speed"] = 41.666666666667,
-          ["type"] = "AH-1W",
-          ["unitId"] = 8,
+          ["speed"] = 0,
+          ["x"] = 0,
+          ["y"] = 0,
+          ["alt"] = 10,
+          ["alt_type"] = "BARO",          
+          ["heading"] = 0,
           ["psi"] = 0,
-          ["parking_id"] = "10",
-          ["x"] = -356168.27327001,
-          ["name"] = "Rotary-1-1",
+          ["parking"] = nil,
+          ["parking_id"] = nil,
           ["payload"] = 
           {
-              ["pylons"] = 
-              {
-              }, -- end of ["pylons"]
+              ["pylons"] = {}, -- end of ["pylons"]
               ["fuel"] = "1250.0",
               ["flare"] = 30,
               ["chaff"] = 30,
               ["gun"] = 100,
           }, -- end of ["payload"]
-          ["y"] = 618351.087765,
-          ["heading"] = 0,
           ["callsign"] = 
           {
               [1] = 2,
@@ -335,15 +603,8 @@ TEMPLATE.GenericHelicopter=
               [3] = 1,
               ["name"] = "Springfield11",
           }, -- end of ["callsign"]
-          ["onboard_num"] = "050",
       }, -- end of [1]
   }, -- end of ["units"]
-  ["y"] = 0,
-  ["x"] = 0,
-  ["name"] = "Rotary-1",
-  ["communication"] = true,
-  ["start_time"] = 0,
-  ["frequency"] = 127.5,
 }
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/Moose Development/Moose/Utilities/Templates.lua
+++ b/Moose Development/Moose/Utilities/Templates.lua
@@ -89,6 +89,42 @@ function TEMPLATE.GetGround(TypeName, GroupName, CountryID, Vec3, Nunits, Radius
   return template
 end
 
+
+
+--- Set the position of the template.
+-- @param #table Template The template to be modified.
+-- @param DCS#Vec2 Vec2 2D Position vector with x and y components of the group.
+function TEMPLATE.SetPositionFromVec2(Template, Vec2)
+
+  Template.x=Vec2.x
+  Template.y=Vec2.y
+  
+  for _,unit in pairs(Template.units) do
+    unit.x=Vec2.x
+    unit.y=Vec2.y
+  end
+  
+  Template.route.points[1].x=Vec2.x
+  Template.route.points[1].y=Vec2.y
+  Template.route.points[1].alt=0 --TODO: Use land height.
+ 
+end
+
+--- Set the position of the template.
+-- @param #table Template The template to be modified.
+-- @param DCS#Vec3 Vec3 Position vector of the group.
+function TEMPLATE.SetPositionFromVec3(Template, Vec3)
+
+  local Vec2={x=Vec3.x, y=Vec3.z}
+  
+  TEMPLATE.SetPositionFromVec2(Template, Vec2)
+  
+end
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Generic Ground Template
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
 TEMPLATE.GenericGround=
 {
   ["visible"] = false,
@@ -152,32 +188,164 @@ TEMPLATE.GenericGround=
   ["start_time"] = 0,
 }
 
---- Set the position of the template.
--- @param #table Template The template to be modified.
--- @param DCS#Vec2 Vec2 2D Position vector with x and y components of the group.
-function TEMPLATE.SetPositionFromVec2(Template, Vec2)
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Generic Ship Template
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-  Template.x=Vec2.x
-  Template.y=Vec2.y
-  
-  for _,unit in pairs(Template.units) do
-    unit.x=Vec2.x
-    unit.y=Vec2.y
-  end
-  
-  Template.route.points[1].x=Vec2.x
-  Template.route.points[1].y=Vec2.y
-  Template.route.points[1].alt=0 --TODO: Use land height.
- 
-end
+TEMPLATE.GenericNaval=
+{
+  ["visible"] = false,
+  ["tasks"] = {}, -- end of ["tasks"]
+  ["uncontrollable"] = false,
+  ["route"] = 
+  {
+      ["points"] = 
+      {
+          [1] = 
+          {
+              ["alt"] = 0,
+              ["type"] = "Turning Point",
+              ["ETA"] = 0,
+              ["alt_type"] = "BARO",
+              ["formation_template"] = "",
+              ["y"] = 0,
+              ["x"] = 0,
+              ["ETA_locked"] = true,
+              ["speed"] = 0,
+              ["action"] = "Turning Point",
+              ["task"] = 
+              {
+                  ["id"] = "ComboTask",
+                  ["params"] = 
+                  {
+                      ["tasks"] = 
+                      {
+                      }, -- end of ["tasks"]
+                  }, -- end of ["params"]
+              }, -- end of ["task"]
+              ["speed_locked"] = true,
+          }, -- end of [1]
+      }, -- end of ["points"]
+  }, -- end of ["route"]
+  ["groupId"] = nil,
+  ["hidden"] = false,
+  ["units"] = 
+  {
+      [1] = 
+      {
+          ["transportable"] = 
+          {
+              ["randomTransportable"] = false,
+          }, -- end of ["transportable"]
+          ["skill"] = "Average",
+          ["type"] = "TICONDEROG",
+          ["unitId"] = nil,
+          ["y"] = 0,
+          ["x"] = 0,
+          ["name"] = "Naval-1-1",
+          ["heading"] = 0,
+          ["modulation"] = 0,
+          ["frequency"] = 127500000,
+      }, -- end of [1]
+  }, -- end of ["units"]
+  ["y"] = 0,
+  ["x"] = 0,
+  ["name"] = "Naval-1",
+  ["start_time"] = 0,
+}
 
---- Set the position of the template.
--- @param #table Template The template to be modified.
--- @param DCS#Vec3 Vec3 Position vector of the group.
-function TEMPLATE.SetPositionFromVec3(Template, Vec3)
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Generic Ship Template
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-  local Vec2={x=Vec3.x, y=Vec3.z}
-  
-  TEMPLATE.SetPositionFromVec2(Template, Vec2)
-  
-end
+TEMPLATE.GenericHelicopter=
+{
+  ["modulation"] = 0,
+  ["tasks"] = {}, -- end of ["tasks"]
+  ["radioSet"] = false,
+  ["task"] = "Nothing",
+  ["uncontrolled"] = false,
+  ["taskSelected"] = true,
+  ["route"] = 
+  {
+      ["points"] = 
+      {
+          [1] = 
+          {
+              ["alt"] = 10,
+              ["action"] = "From Parking Area",
+              ["alt_type"] = "BARO",
+              ["speed"] = 41.666666666667,
+              ["task"] = 
+              {
+                  ["id"] = "ComboTask",
+                  ["params"] = 
+                  {
+                      ["tasks"] = 
+                      {
+                      }, -- end of ["tasks"]
+                  }, -- end of ["params"]
+              }, -- end of ["task"]
+              ["type"] = "TakeOffParking",
+              ["ETA"] = 0,
+              ["ETA_locked"] = true,
+              ["y"] = 618351.087765,
+              ["x"] = -356168.27327001,
+              ["formation_template"] = "",
+              ["airdromeId"] = 22,
+              ["speed_locked"] = true,
+          }, -- end of [1]
+      }, -- end of ["points"]
+  }, -- end of ["route"]
+  ["groupId"] = nil,
+  ["hidden"] = false,
+  ["units"] = 
+  {
+      [1] = 
+      {
+          ["alt"] = 10,
+          ["alt_type"] = "BARO",
+          ["livery_id"] = "USA X Black",
+          ["skill"] = "High",
+          ["parking"] = "4",
+          ["ropeLength"] = 15,
+          ["speed"] = 41.666666666667,
+          ["type"] = "AH-1W",
+          ["unitId"] = 8,
+          ["psi"] = 0,
+          ["parking_id"] = "10",
+          ["x"] = -356168.27327001,
+          ["name"] = "Rotary-1-1",
+          ["payload"] = 
+          {
+              ["pylons"] = 
+              {
+              }, -- end of ["pylons"]
+              ["fuel"] = "1250.0",
+              ["flare"] = 30,
+              ["chaff"] = 30,
+              ["gun"] = 100,
+          }, -- end of ["payload"]
+          ["y"] = 618351.087765,
+          ["heading"] = 0,
+          ["callsign"] = 
+          {
+              [1] = 2,
+              [2] = 1,
+              [3] = 1,
+              ["name"] = "Springfield11",
+          }, -- end of ["callsign"]
+          ["onboard_num"] = "050",
+      }, -- end of [1]
+  }, -- end of ["units"]
+  ["y"] = 0,
+  ["x"] = 0,
+  ["name"] = "Rotary-1",
+  ["communication"] = true,
+  ["start_time"] = 0,
+  ["frequency"] = 127.5,
+}
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+

--- a/Moose Development/Moose/Utilities/Utils.lua
+++ b/Moose Development/Moose/Utilities/Utils.lua
@@ -652,6 +652,17 @@ function UTILS.GetMarkID()
 
 end
 
+--- Remove an object (marker, circle, arrow, text, quad, ...) on the F10 map.
+-- @param #number MarkID Unique ID of the object.
+-- @param #number Delay (Optional) Delay in seconds before the mark is removed.
+function UTILS.RemoveMark(MarkID, Delay)
+  if Delay and Delay>0 then
+    TIMER:New(UTILS.RemoveMark, MarkID):Start(Delay)
+  else
+    trigger.action.removeMark(MarkID)
+  end
+end
+
 
 -- Test if a Vec2 is in a radius of another Vec2
 function UTILS.IsInRadius( InVec2, Vec2, Radius )

--- a/Moose Development/Moose/Wrapper/Group.lua
+++ b/Moose Development/Moose/Wrapper/Group.lua
@@ -2551,9 +2551,10 @@ do -- Players
   
 end
 
---- GROUND - Switch on/off radar emissions
+--- GROUND - Switch on/off radar emissions for the group.
 -- @param #GROUP self
--- @param #boolean switch
+-- @param #boolean switch If true, emission is enabled. If false, emission is disabled.
+-- @return #GROUP self 
 function GROUP:EnableEmission(switch)
   self:F2( self.GroupName )
   local switch = switch or false
@@ -2566,6 +2567,7 @@ function GROUP:EnableEmission(switch)
 
   end
 
+  return self
 end
 
 --do -- Smoke

--- a/Moose Development/Moose/Wrapper/Unit.lua
+++ b/Moose Development/Moose/Wrapper/Unit.lua
@@ -761,40 +761,6 @@ function UNIT:GetFuel()
   return nil
 end
 
---- Sets the passed group or unit objects radar emitters on or off. Can be used on sam sites for example to shut down the radar without setting AI off or changing the alarm state.
--- @param #UNIT self
--- @param #boolean Switch If `true` or `nil`, emission is enabled. If `false`, emission is turned off.
--- @return #UNIT self 
-function UNIT:SetEmission(Switch)
-
-  if Switch==nil then
-    Switch=true
-  end
-
-  local DCSUnit = self:GetDCSObject()
-  
-  if DCSUnit then
-    DCSUnit:enableEmission(Switch)
-  end
-  
-  return self
-end
-
---- Sets the passed group or unit objects radar emitters ON. Can be used on sam sites for example to shut down the radar without setting AI off or changing the alarm state.
--- @param #UNIT self
--- @return #UNIT self 
-function UNIT:EnableEmission()
-  self:SetEmission(true)
-  return self
-end
-
---- Sets the passed group or unit objects radar emitters OFF. Can be used on sam sites for example to shut down the radar without setting AI off or changing the alarm state.
--- @param #UNIT self
--- @return #UNIT self 
-function UNIT:DisableEmission()
-  self:SetEmission(false)
-  return self
-end
 
 --- Returns a list of one @{Wrapper.Unit}.
 -- @param #UNIT self
@@ -1429,9 +1395,10 @@ function UNIT:GetTemplateFuel()
   return nil
 end
 
---- GROUND - Switch on/off radar emissions.
+--- GROUND - Switch on/off radar emissions of a unit.
 -- @param #UNIT self
--- @param #boolean switch
+-- @param #boolean switch If true, emission is enabled. If false, emission is disabled. 
+-- @return #UNIT self
 function UNIT:EnableEmission(switch)
   self:F2( self.UnitName )
   
@@ -1445,4 +1412,5 @@ function UNIT:EnableEmission(switch)
 
   end
 
+  return self
 end

--- a/Moose Setup/Moose.files
+++ b/Moose Setup/Moose.files
@@ -3,6 +3,7 @@ Utilities/Routines.lua
 Utilities/Utils.lua
 Utilities/Enums.lua
 Utilities/Profiler.lua
+Utilities/Templates.lua
 
 Core/Base.lua
 Core/UserFlag.lua


### PR DESCRIPTION
**DATABASE**
- Quad zones defined in the ME are registered as polygon zones.

**COORDINATE**
Added new functions to draw shapes on the F10 map:
- `COORDINATE:LineToAll`
- `COORDINATE:CircleToAll`
- `COORDINATE:RectToAll`
- `COORDINATE:QuadToAll`
- `COORDINATE:MarkupToAllFreeForm`
- `COORDINATE:TextToAll`
- `COORDINATE:ArrowToAll`

**ZONE**
Added new functions to draw zones on the F10 map:
- `ZONE_RADIUS:DrawZone`
- `ZONE_POLYGON_BASE:DrawZone`
- Added color option.
- Added vertex function for poly zones.

**DCS**
- Added new country enums.

**TEMPLATES**
- Added new WIP class to create templates from scratch.

