### PR TITLE
Update Spawn.lua #1543

### DIFF
--- a/Moose Development/Moose/Core/Spawn.lua
+++ b/Moose Development/Moose/Core/Spawn.lua
@@ -3406,10 +3406,10 @@ function SPAWN:_SpawnCleanUpScheduler()
       self:T( { SpawnUnitName, Stamp } )
 	    
 	    if Stamp.Vec2 then
-    		if SpawnUnit:InAir() == false and SpawnUnit:GetVelocityKMH() < 1 then
+    		if (Stamp.Vec2.x == NewVec2.x and Stamp.Vec2.y == NewVec2.y) or (SpawnUnit:GetLife() <= 1) then
     		  local NewVec2 = SpawnUnit:GetVec2()
     		  if Stamp.Vec2.x == NewVec2.x and Stamp.Vec2.y == NewVec2.y then
-      		  -- If the plane is not moving, and is on the ground, assign it with a timestamp...
+      		  -- If the plane is not moving or dead, and is on the ground, assign it with a timestamp...
     				if Stamp.Time + self.SpawnCleanUpInterval < timer.getTime() then
     					self:T( { "CleanUp Scheduler:", "ReSpawning:", SpawnGroup:GetName() } )
     					self:ReSpawn( SpawnCursor )


### PR DESCRIPTION
Update InitCleanup() Scheduler to also check for lifepoints. Note - will not catch the rare case that a dead unit still spins in mid-air. #1543 