### PR TITLE
Update Airboss debug msg with BRC/Final heading

### DIFF
--- a/Moose Development/Moose/Ops/Airboss.lua
+++ b/Moose Development/Moose/Ops/Airboss.lua
@@ -15526,8 +15526,12 @@ function AIRBOSS:_MarshalCallRecoveryStart(case)
 
   -- Debug output.
   local text=string.format("Starting aircraft recovery Case %d ops.", case)
-  if case>1 then
-    text=text..string.format(" Marshal radial %03d°.", radial)
+  if case==1 then
+    text=text..string.format(" BRC %03d°.", self:GetBRC())
+  elseif case==2 then
+    text=text..string.format(" Marshal radial %03d°. BRC %03d°.", radial, self:GetBRC())
+  elseif case==3 then
+    text=text..string.format(" Marshal radial %03d°. Final heading %03d°.", radial, self:GetFinalBearing(false))
   end
   self:T(self.lid..text)
 


### PR DESCRIPTION
# What?

Including the BRC and Final Heading on the debug message is useful for squadrons relying on that msg to know what is the end heading of the carrier.

The carrier tends to turns a few times before ending up on the final heading as it adjust into its track. Thus, having the BRC/Final Heading on the last message "Starting aircraft recovery Case %d ops." is useful.