### PR TITLE
Synchronize Text with Wrapper State

### DIFF
--- a/Moose Development/Moose/Wrapper/Marker.lua
+++ b/Moose Development/Moose/Wrapper/Marker.lua
@@ -673,9 +673,9 @@ function MARKER:OnEventMarkChange(EventData)
 
     if MarkID==self.mid then
 
-      self:Changed(EventData)
+      self.text=tostring(EventData.MarkText)
 
-      self:TextChanged(tostring(EventData.MarkText))
+      self:Changed(EventData)
 
     end
 


### PR DESCRIPTION
Two issues resolved in the implementation

* Bug - text is not synchronized with the wrapper state, hence the `GetText()` will be incorrect.

* Method `TextChanged` does not exist, resulting `nil` reference errors when the players update markers. Current implementation of `MARKER:OnEventMarkChange(EventData)` is not implemented the same as its siblings of `OnEventMarkRemoved` and `OnEventMarkAdded`. The siblings would move the FSM accordingly -- aligned implementation. Quick reference to compare: https://github.com/FlightControl-Master/MOOSE/blob/a14bca1059fa47770eeacb5bd66b276ef6b1626b/Moose%20Development/Moose/Wrapper/Marker.lua#L620-L638