### PR TITLE
CTLD: Enable mass on cargo

### DIFF
--- a/Moose Development/Moose/Wrapper/Unit.lua
+++ b/Moose Development/Moose/Wrapper/Unit.lua
@@ -580,6 +580,18 @@ function UNIT:GetAmmo()
   return nil
 end
 
+--- Sets the Unit's Internal Cargo Mass, in kg
+-- @param #UNIT self
+-- @param #number mass to set cargo to
+-- @return #UNIT self
+function UNIT:SetUnitInternalCargo(mass)
+  local DCSUnit = self:GetDCSObject()
+  if DCSUnit then
+    trigger.action.setUnitInternalCargo(DCSUnit:getName(), mass)
+  end
+  return self
+end
+
 --- Get the number of ammunition and in particular the number of shells, rockets, bombs and missiles a unit currently has.
 -- @param #UNIT self
 -- @return #number Total amount of ammo the unit has left. This is the sum of shells, rockets, bombs and missiles.


### PR DESCRIPTION
Add PerCrateMass to CTLD_CARGO (default = 0kg)
Update unit internal cargo after each load/unload operation.
Add mass to cargo reports
Fix repairs appearing at location of Heli, not the location of the original group