### PR TITLE
Airboss v/stol

### DIFF
--- a/Moose Development/Moose/Ops/Airboss.lua
+++ b/Moose Development/Moose/Ops/Airboss.lua
@@ -12206,6 +12206,7 @@ end
 -- * > 24 seconds: No Grade "--"
 --
 -- If you manage to be between 16.4 and and 16.6 seconds, you will even get and okay underline "\_OK\_".
+-- No groove time for Harrier on LHA, LHD set to Tgroove Unicorn as starting point to allow possible _OK_ 5.0.
 --
 -- @param #AIRBOSS self
 -- @param #AIRBOSS.PlayerData playerData Player data table.
@@ -12224,6 +12225,8 @@ function AIRBOSS:_EvalGrooveTime(playerData)
     grade="OK Groove"
   elseif t<=24 then
     grade="(LIG)"
+  elseif t>=25 and aircrafttype~=AIRBOSS.AircraftCarrier.AV8B then -- VSTOL Operations with AV-8B
+    grade="OK V/STOL Groove"
   else
     grade="LIG"
   end
@@ -12258,7 +12261,7 @@ function AIRBOSS:_LSOgrade(playerData)
   -- Put everything together.
   local G=GXX.." "..GIM.." ".." "..GIC.." "..GAR
 
-  -- Count number of minor, normal and major deviations.
+  -- Count number of minor, normal and major deviations. TODO - work on Harrier counts due slower approach speed.
   local N=nXX+nIM+nIC+nAR
   local nL=count(G, '_')/2
   local nS=count(G, '%(')
@@ -12270,8 +12273,8 @@ function AIRBOSS:_LSOgrade(playerData)
 
   local grade
   local points
-  if N==0 and TgrooveUnicorn then
-    -- No deviations, should be REALLY RARE!
+  if N==0 and (TgrooveUnicorn or aircrafttype~=AIRBOSS.AircraftCarrier.AV8B) then
+    -- No deviations, should be REALLY RARE! Grove time for AV-8B Harrier not required, possible to still get Unicorn.
     grade="_OK_"
     points=5.0
     G="Unicorn"

--- a/Moose Development/Moose/Ops/Airboss.lua
+++ b/Moose Development/Moose/Ops/Airboss.lua
@@ -12252,7 +12252,7 @@ function AIRBOSS:_LSOgrade(playerData)
     return select(2, string.gsub(base, pattern, ""))
   end
 
-  -- Analyse flight data and conver to LSO text.
+  -- Analyse flight data and convert to LSO text.
   local GXX,nXX=self:_Flightdata2Text(playerData, AIRBOSS.GroovePos.XX)
   local GIM,nIM=self:_Flightdata2Text(playerData, AIRBOSS.GroovePos.IM)
   local GIC,nIC=self:_Flightdata2Text(playerData, AIRBOSS.GroovePos.IC)
@@ -12285,6 +12285,22 @@ function AIRBOSS:_LSOgrade(playerData)
       points=2.0
     elseif nN>0 then
       -- No larger but average deviations ==>  "Fair Pass" Pass with average deviations and corrections.
+      grade="(OK)"
+      points=3.0
+    else
+      -- Only minor corrections
+      grade="OK"
+      points=4.0
+    end
+	  -- Add AV-8B Harrier devation allowances due to lower groundspeed and 3x conventional groove time, this allows to maintain LSO tolerances while respecting the deviations are not unsafe. (WIP requires feedback)
+      -- Large devaitions still result in a No Grade, A Unicorn still requires a clean pass with no deviation.
+	if nL>2 and aircrafttype~=AIRBOSS.AircraftCarrier.AV8B then 
+      -- Larger deviations ==> "No grade" 2.0 points.
+      grade="--"
+      points=2.0
+	  
+	elseif nN>2 and aircrafttype~=AIRBOSS.AircraftCarrier.AV8B then
+      -- Only average deviations ==>  "Fair Pass" Pass with average deviations and corrections.
       grade="(OK)"
       points=3.0
     else

--- a/Moose Development/Moose/Ops/Airboss.lua
+++ b/Moose Development/Moose/Ops/Airboss.lua
@@ -50,8 +50,8 @@
 --
 -- At the moment, optimized parameters are available for the F/A-18C Hornet (Lot 20) and A-4E community mod as aircraft and the USS John C. Stennis as carrier.
 --
--- The AV-8B Harrier and the USS Tarawa, USS America and Juan Carlos I are WIP. Those two can only be used together, i.e. these ships are the only carriers the harrier is supposed to land on and
--- the no other fixed wing aircraft (human or AI controlled) are supposed to land on these ships. Currently only Case I is supported. Case II/III take slightly different steps from the CVN carrier.
+-- The AV-8B Harrier, the USS Tarawa, USS America and Juan Carlos I are WIP. The AV-8B harrier and the LHA's and LHD can only be used together, i.e. these ships are the only carriers the harrier is supposed to land on and
+-- no other fixed wing aircraft (human or AI controlled) are supposed to land on these ships. Currently only Case I is supported. Case II/III take slightly different steps from the CVN carrier.
 -- However, the two Case II/III pattern are very similar so this is not a big drawback.
 --
 -- Heatblur's mighty F-14B Tomcat has been added (March 13th 2019) as well. Same goes for the A version.
@@ -298,8 +298,8 @@
 -- ![Banner Image](..\Presentations\AIRBOSS\Airboss_Case1_Landing.png)
 --
 -- Once the aircraft reaches the Initial, the landing pattern begins. The important steps of the pattern are shown in the image above.
--- The AV-8B Harrier pattern is very similar, the only differences are as there is no angled deck there is no wake check. from the ninety you wil fly strait in to 26 ft to port of the tram line.
--- The aim is to arrive abeam the landing spot in a stable hover at 120 ft with forward speed matched to the boat. From there the LSO will call "cleared to land". You then cross to the tram line at the designated landing spot at land vertcally. 
+-- The AV-8B Harrier pattern is very similar, the only differences are as there is no angled deck there is no wake check. from the ninety you wil fly a straight approach offset 26 ft to port (left) of the tram line.
+-- The aim is to arrive abeam the landing spot in a stable hover at 120 ft with forward speed matched to the boat. From there the LSO will call "cleared to land". You then level cross to the tram line at the designated landing spot at land vertcally. 
 --
 --
 -- ## CASE III
@@ -1261,7 +1261,7 @@ AIRBOSS = {
 
 --- Aircraft types capable of landing on carrier (human+AI).
 -- @type AIRBOSS.AircraftCarrier
--- @field #string AV8B AV-8B Night Harrier. Works only with the USS Tarawa.
+-- @field #string AV8B AV-8B Night Harrier. Works only with the USS Tarawa, USS America and Juan Carlos I.
 -- @field #string A4EC A-4E Community mod.
 -- @field #string HORNET F/A-18C Lot 20 Hornet by Eagle Dynamics.
 -- @field #string F14A F-14A by Heatblur.
@@ -1429,8 +1429,8 @@ AIRBOSS.PatternStep={
 -- @field #string IM "IM": In the middle.
 -- @field #string IC "IC": In close.
 -- @field #string AR "AR": At the ramp.
--- @field #string AL "AL": Abeam landing position (Tarawa).
--- @field #string LC "LC": Level crossing (Tarawa).
+-- @field #string AL "AL": Abeam landing position (V/STOL).
+-- @field #string LC "LC": Level crossing (V/STOL).
 -- @field #string IW "IW": In the wires.
 AIRBOSS.GroovePos={
   X0="X0",


### PR DESCRIPTION
- Added grove timing for Harrier to allow players to monitor early hover stop selection and slow final approach speeds.
- Allow for possibility of AV-8B unicorn if no deviations recorded.
- WIP deviation count allowance for low ground speed on final approach and time taken to regain optimal flight path, but retain accuracy requirements for deviations and LSO calls. 
- amend docs to reflect the two additional V/STOL carriers and provide more detail on required pattern.