### PR TITLE
DATABASE

### DIFF
--- a/Moose Development/Moose/Core/Database.lua
+++ b/Moose Development/Moose/Core/Database.lua
@@ -136,7 +136,7 @@ function DATABASE:New()
   self:_RegisterGroupsAndUnits()
   self:_RegisterClients()
   self:_RegisterStatics()
-  self:_RegisterAirbases()
+  --self:_RegisterAirbases()
   --self:_RegisterPlayers()
 
   self.UNITS_Position = 0

--- a/Moose Development/Moose/Globals.lua
+++ b/Moose Development/Moose/Globals.lua
@@ -18,6 +18,7 @@ _DATABASE:_RegisterCargos()
 
 --- Register zones.
 _DATABASE:_RegisterZones()
+_DATABASE:_RegisterAirbases()
 
 --- Check if os etc is available.
 BASE:I("Checking de-sanitization of os, io and lfs:")

--- a/Moose Development/Moose/Wrapper/Airbase.lua
+++ b/Moose Development/Moose/Wrapper/Airbase.lua
@@ -552,7 +552,8 @@ function AIRBASE:Register(AirbaseName)
       self.isHelipad=true
       self.isShip=false
       self.category=Airbase.Category.HELIPAD
-      _DATABASE:AddStatic(AirbaseName)	
+      _DATABASE:AddStatic(AirbaseName)
+	end
   else
     self:E("ERROR: Unknown airbase category!")
   end

--- a/Moose Development/Moose/Wrapper/Airbase.lua
+++ b/Moose Development/Moose/Wrapper/Airbase.lua
@@ -547,6 +547,12 @@ function AIRBASE:Register(AirbaseName)
     self.isHelipad=true
   elseif self.category==Airbase.Category.SHIP then
     self.isShip=true
+    -- DCS bug: Oil rigs and gas platforms have category=2 (ship). Also they cannot be retrieved by coalition.getStaticObjects()
+    if self.descriptors.typeName=="Oil rig" or self.descriptors.typeName=="Ga" then
+      self.isHelipad=true
+      self.isShip=false
+      self.category=Airbase.Category.HELIPAD
+      _DATABASE:AddStatic(AirbaseName)	
   else
     self:E("ERROR: Unknown airbase category!")
   end


### PR DESCRIPTION
Moved `DATABASE:RegisterAirbases()` from Database.lua to Globals.lua
Workaround for DCS bug registering oil rigs and gas platforms as ships (not helipads).