### PR TITLE
Enabled SSML when using Google text-to-speech.

### DIFF
--- a/Moose Development/Moose/Sound/SRS.lua
+++ b/Moose Development/Moose/Sound/SRS.lua
@@ -88,10 +88,19 @@
 -- 
 -- Use a specific "culture" with the @{#MSRS.SetCulture} function, e.g. `:SetCulture("en-US")` or `:SetCulture("de-DE")`.
 -- 
+-- ## Set Google
+-- 
+-- Use Google's text-to-speech engine with the @{#MSRS.SetGoogle} function, e.g. ':SetGoogle()'.
+-- By enabling this it also allows you to utilize SSML in your text for added flexibilty.
+-- For more information on setting up a cloud account, visit: https://cloud.google.com/text-to-speech
+-- Google's supported SSML reference: https://cloud.google.com/text-to-speech/docs/ssml
+-- 
 -- ## Set Voice
 -- 
 -- Use a specifc voice with the @{#MSRS.SetVoice} function, e.g, `:SetVoice("Microsoft Hedda Desktop")`.
 -- Note that this must be installed on your windows system.
+-- If enabling SetGoogle(), you can use voices provided by Google
+-- Google's supported voices: https://cloud.google.com/text-to-speech/docs/voices
 -- 
 -- ## Set Coordinate
 -- 
@@ -678,7 +687,7 @@ function MSRS:_GetCommand(freqs, modus, coal, gender, voice, culture, volume, sp
   
   -- Set google.
   if self.google then
-    command=command..string.format(' -G "%s"', self.google)
+    command=command..string.format(' --ssml -G "%s"', self.google)
   end
   
   -- Debug output.


### PR DESCRIPTION
Added --ssml command line option that will enable SSML text when using Google text-to-speech.
- Supported by DCS-SR-ExternalAudio
- Can still send 'normal' text messages. 
```lua 
MSRS:PlayText("This is a message.")
```
- Use SSML just by adding the appropriate markup.
```lua
MSRS:PlayText("<speak><break time='500ms'/><emphasis level='strong'><s>This is a message.</s></emphasis></speak>"
```