### PR TITLE
Replace log MESSAGE when updating cluster markers in INTEL with a log

### DIFF
--- a/Moose Development/Moose/Ops/Intelligence.lua
+++ b/Moose Development/Moose/Ops/Intelligence.lua
@@ -1472,8 +1472,10 @@ function INTEL:PaintPicture()
       --local coordinate=self:GetClusterCoordinate(cluster)
 
       -- Update F10 marker.
-      MESSAGE:New("Updating cluster marker and future position", 10):ToAll()
-
+      if self.verbose >= 1 then
+        BASE:I("Updating cluster marker and future position")
+      end
+      
       -- Update cluster markers.
       self:UpdateClusterMarker(cluster)
 


### PR DESCRIPTION
There might be an argument to delete that log altogether since it's spamming quite a lot (one log per cluster)