### PR TITLE
Fix ATIS SRS TTS readouts for wind direction & TACAN

### DIFF
--- a/Moose Development/Moose/Ops/ATIS.lua
+++ b/Moose Development/Moose/Ops/ATIS.lua
@@ -1740,6 +1740,10 @@ function ATIS:onafterBroadcast( From, Event, To )
   end
 
   -- Wind
+  -- Adding a space after each digit of WINDFROM to convert this to aviation-speak for TTS via SRS
+  if self.useSRS then
+    WINDFROM = string.gsub(WINDFROM,".", "%1 ")
+    end 
   if self.metric then
     subtitle = string.format( "Wind from %s at %s m/s", WINDFROM, WINDSPEED )
   else
@@ -2197,7 +2201,7 @@ function ATIS:onafterBroadcast( From, Event, To )
 
   -- TACAN
   if self.tacan then
-    subtitle = string.format( "TACAN channel %dX", self.tacan )
+    subtitle = string.format( "TACAN channel %dX Ray", self.tacan )
     if not self.useSRS then
       self:Transmission( ATIS.Sound.TACANChannel, 1.0, subtitle )
       self.radioqueue:Number2Transmission( tostring( self.tacan ), nil, 0.2 )


### PR DESCRIPTION
- Added a substitution that takes effect when self.useSRS which converts wind direction into aviation-speak, e.g. "Zero Seven One" instead of the previous behaviour which was "Zero Seventy-One".

- Updated TACAN TTS string to include the 'Ray' in 'X-Ray' when SRS is in use