### PR TITLE
Custom TTS callsigns

### DIFF
--- a/Moose Development/Moose/Ops/Awacs.lua
+++ b/Moose Development/Moose/Ops/Awacs.lua
@@ -911,6 +911,8 @@ function AWACS:New(Name,AirWing,Coalition,AirbaseName,AwacsOrbit,OpsZone,Station
   -- Escorts
   self.HasEscorts = false
   self.EscortTemplate = ""
+  self.EscortMission = {}
+  self.EscortMissionReplacement = {}
   
   -- SRS
   self.PathToSRS = "C:\\Program Files\\DCS-SimpleRadio-Standalone"
@@ -1721,20 +1723,21 @@ function AWACS:_StartEscorts(Shiftchange)
   
   local AwacsFG = self.AwacsFG -- Ops.FlightGroup#FLIGHTGROUP
   local group = AwacsFG:GetGroup()
-  local mission = AUFTRAG:NewESCORT(group,{x=-100, y=0, z=200},45,{"Air"})
-  self.CatchAllMissions[#self.CatchAllMissions+1] = mission
-  
-  mission:SetRequiredAssets(self.EscortNumber)
   
   local timeonstation = (self.EscortsTimeOnStation + self.ShiftChangeTime) * 3600 -- hours to seconds
-  mission:SetTime(nil,timeonstation)
-  
-  self.AirWing:AddMission(mission)
-  
-  if Shiftchange then
-    self.EscortMissionReplacement = mission
-  else
-    self.EscortMission = mission
+  for i=1,self.EscortNumber do
+    -- every 
+    local escort = AUFTRAG:NewESCORT(group, {x= -100*((i + (i%2))/2), y=0, z=(100 + 100*((i + (i%2))/2))*(-1)^i},45,{"Air"})
+    escort:SetRequiredAssets(1)
+    escort:SetTime(nil,timeonstation)
+    self.AirWing:AddMission(escort)
+    self.CatchAllMissions[#self.CatchAllMissions+1] = escort
+
+    if Shiftchange then
+      self.EscortMissionReplacement[i] = mission
+    else
+      self.EscortMission[i] = mission
+    end
   end
   
   return self
@@ -5578,57 +5581,27 @@ function AWACS:_CheckAwacsStatus()
     --------------------------------
                        
     if self.HasEscorts then
-      local ESmission = self.EscortMission -- Ops.Auftrag#AUFTRAG
-      local esstatus = ESmission:GetState()
-      local ESmissiontime = (timer.getTime() - self.EscortsTimeStamp)
-      local ESTOSLeft = UTILS.Round((((self.EscortsTimeOnStation+self.ShiftChangeTime)*3600) - ESmissiontime),0) -- seconds
-      ESTOSLeft = UTILS.Round(ESTOSLeft/60,0) -- minutes
-      local ChangeTime = UTILS.Round(((self.ShiftChangeTime * 3600)/60),0)
-      local Changedue = "No"
-      
-      if (ESTOSLeft <= ChangeTime and not self.ShiftChangeEscortsFlag) or (ESmission:IsOver() and not self.ShiftChangeEscortsFlag) then 
-        Changedue = "Yes" 
-        self.ShiftChangeEscortsFlag = true -- set this back when new Escorts arrived
-        self:__EscortShiftChange(2)
-      end
-      
-      report:Add("====================")
-      report:Add("ESCORTS:")
-      report:Add(string.format("Auftrag Status: %s",esstatus))
-      report:Add(string.format("TOS Left: %d min",ESTOSLeft))
-      report:Add(string.format("Needs ShiftChange: %s",Changedue))
-      
-      local OpsGroups = ESmission:GetOpsGroups()
-      local OpsGroup = self:_GetAliveOpsGroupFromTable(OpsGroups) -- Ops.OpsGroup#OPSGROUP
-      if OpsGroup then
-        local OpsName = OpsGroup:GetName() or "Unknown"
-        local OpsCallSign = OpsGroup:GetCallsignName() or "Unknown"
-        report:Add(string.format("Mission FG %s",OpsName))
-        report:Add(string.format("Callsign %s",OpsCallSign))
-        report:Add(string.format("Mission FG State %s",OpsGroup:GetState()))
-        monitoringdata.EscortsStateMission = esstatus
-        monitoringdata.EscortsStateFG = OpsGroup:GetState()
-      else
-        report:Add("***** Cannot obtain (yet) this missions OpsGroup!")
-      end
-      
-      report:Add("====================")
-      
-      -- Check for replacement mission - if any
-      if self.ShiftChangeEscortsFlag and self.ShiftChangeEscortsRequested then -- Ops.Auftrag#AUFTRAG
-        ESmission = self.EscortMissionReplacement
+      for i=1, self.EscortNumber do
+        local ESmission = self.EscortMission[i] -- Ops.Auftrag#AUFTRAG
+        if not ESmission then break end
         local esstatus = ESmission:GetState()
         local ESmissiontime = (timer.getTime() - self.EscortsTimeStamp)
         local ESTOSLeft = UTILS.Round((((self.EscortsTimeOnStation+self.ShiftChangeTime)*3600) - ESmissiontime),0) -- seconds
         ESTOSLeft = UTILS.Round(ESTOSLeft/60,0) -- minutes
         local ChangeTime = UTILS.Round(((self.ShiftChangeTime * 3600)/60),0)
-        --local Changedue = "No"
+        local Changedue = "No"
         
-        --report:Add("====================")
-        report:Add("ESCORTS REPLACEMENT:")
+        if (ESTOSLeft <= ChangeTime and not self.ShiftChangeEscortsFlag) or (ESmission:IsOver() and not self.ShiftChangeEscortsFlag) then 
+          Changedue = "Yes" 
+          self.ShiftChangeEscortsFlag = true -- set this back when new Escorts arrived
+          self:__EscortShiftChange(2)
+        end
+        
+        report:Add("====================")
+        report:Add("ESCORTS:")
         report:Add(string.format("Auftrag Status: %s",esstatus))
         report:Add(string.format("TOS Left: %d min",ESTOSLeft))
-        --report:Add(string.format("Needs ShiftChange: %s",Changedue))
+        report:Add(string.format("Needs ShiftChange: %s",Changedue))
         
         local OpsGroups = ESmission:GetOpsGroups()
         local OpsGroup = self:_GetAliveOpsGroupFromTable(OpsGroups) -- Ops.OpsGroup#OPSGROUP
@@ -5638,24 +5611,57 @@ function AWACS:_CheckAwacsStatus()
           report:Add(string.format("Mission FG %s",OpsName))
           report:Add(string.format("Callsign %s",OpsCallSign))
           report:Add(string.format("Mission FG State %s",OpsGroup:GetState()))
+          monitoringdata.EscortsStateMission[i] = esstatus
+          monitoringdata.EscortsStateFG[i] = OpsGroup:GetState()
         else
           report:Add("***** Cannot obtain (yet) this missions OpsGroup!")
         end
         
-        if ESmission:IsExecuting() then
-          -- make the actual change in the queue
-          self.ShiftChangeEscortsFlag = false
-          self.ShiftChangeEscortsRequested = false
-          -- cancel old mission
-          if self.EscortMission and self.EscortMission:IsNotOver() then
-              self.EscortMission:Cancel()
-          end
-          self.EscortMission = self.EscortMissionReplacement
-          self.EscortMissionReplacement = nil
-          self.EscortsTimeStamp = timer.getTime()
-          report:Add("*** Replacement DONE ***")
-        end
         report:Add("====================")
+        
+        -- Check for replacement mission - if any
+        if self.ShiftChangeEscortsFlag and self.ShiftChangeEscortsRequested then -- Ops.Auftrag#AUFTRAG
+          ESmission = self.EscortMissionReplacement[i]
+          local esstatus = ESmission:GetState()
+          local ESmissiontime = (timer.getTime() - self.EscortsTimeStamp)
+          local ESTOSLeft = UTILS.Round((((self.EscortsTimeOnStation+self.ShiftChangeTime)*3600) - ESmissiontime),0) -- seconds
+          ESTOSLeft = UTILS.Round(ESTOSLeft/60,0) -- minutes
+          local ChangeTime = UTILS.Round(((self.ShiftChangeTime * 3600)/60),0)
+          --local Changedue = "No"
+          
+          --report:Add("====================")
+          report:Add("ESCORTS REPLACEMENT:")
+          report:Add(string.format("Auftrag Status: %s",esstatus))
+          report:Add(string.format("TOS Left: %d min",ESTOSLeft))
+          --report:Add(string.format("Needs ShiftChange: %s",Changedue))
+          
+          local OpsGroups = ESmission:GetOpsGroups()
+          local OpsGroup = self:_GetAliveOpsGroupFromTable(OpsGroups) -- Ops.OpsGroup#OPSGROUP
+          if OpsGroup then
+            local OpsName = OpsGroup:GetName() or "Unknown"
+            local OpsCallSign = OpsGroup:GetCallsignName() or "Unknown"
+            report:Add(string.format("Mission FG %s",OpsName))
+            report:Add(string.format("Callsign %s",OpsCallSign))
+            report:Add(string.format("Mission FG State %s",OpsGroup:GetState()))
+          else
+            report:Add("***** Cannot obtain (yet) this missions OpsGroup!")
+          end
+          
+          if ESmission:IsExecuting() then
+            -- make the actual change in the queue
+            self.ShiftChangeEscortsFlag = false
+            self.ShiftChangeEscortsRequested = false
+            -- cancel old mission
+            if ESmission and ESmission:IsNotOver() then
+                ESmission:Cancel()
+            end
+            self.EscortMission[i] = self.EscortMissionReplacement[i]
+            self.EscortMissionReplacement[i] = nil
+            self.EscortsTimeStamp = timer.getTime()
+            report:Add("*** Replacement DONE ***")
+          end
+          report:Add("====================")
+        end
       end
     end
       

--- a/Moose Development/Moose/Ops/Awacs.lua
+++ b/Moose Development/Moose/Ops/Awacs.lua
@@ -252,14 +252,6 @@ do
 --            testawacs:SetAwacsDetails(CALLSIGN.AWACS.Wizard)
 --            -- And start as GCI using a group name "Blue EWR" as main EWR station
 --            testawacs:SetAsGCI(GROUP:FindByName("Blue EWR"),2)
---            -- Set Custom Callsigns for use with TTS
---            testawacs:SetCustomCallsigns({
---              Devil = 'Bengal',
---              Snake = 'Winder',
---              Colt = 'Camelot',
---              Enfield = 'Victory',
---              Uzi = 'Evil Eye'
---            })
 --            testawacs:__Start(4)
 --            
 -- ## 6 Menu entries
@@ -954,7 +946,6 @@ function AWACS:New(Name,AirWing,Coalition,AirbaseName,AwacsOrbit,OpsZone,Station
   -- managed groups
   self.ManagedGrps = {} -- #table of #AWACS.ManagedGroup entries
   self.ManagedGrpID = 0  
-  self.callsignTranslations = nil
   
   -- Anchor stacks init
   self.AnchorStacks = FIFO:New() -- Utilities.FiFo#FIFO
@@ -971,7 +962,7 @@ function AWACS:New(Name,AirWing,Coalition,AirbaseName,AwacsOrbit,OpsZone,Station
   -- Task lists
   self.ManagedTasks = FIFO:New() -- Utilities.FiFo#FIFO
   --self.OpenTasks = FIFO:New() -- Utilities.FiFo#FIFO
-
+  
   -- Monitoring, init
   local MonitoringData = {} -- #AWACS.MonitoringData
   MonitoringData.AICAPCurrent = 0
@@ -1274,14 +1265,6 @@ function AWACS:ZipLip()
   --self.NoGroupTags = true
   self.NoMissileCalls = true
   return self
-end
-
---- [User] Do not show messages on screen
--- @param #AWACS self
--- @param #table table with DCS callsigns as keys and replacements as values
--- @return #AWACS self
-function AWACS:SetCustomCallsigns(translationTable) 
-  self.callsignTranslations = translationTable
 end
 
 --- [Internal] Event handler
@@ -1953,11 +1936,6 @@ function AWACS:_GetCallSign(Group,GID)
   local callsign = "Ghost 1"
   if Group and Group:IsAlive() then
     local shortcallsign = Group:GetCallsign() or "unknown11"-- e.g.Uzi11, but we want Uzi 1 1
-    local callsignroot = string.match(shortcallsign, '(%a+)')
-    if self.callsignTranslations[callsignroot] then
-      shortcallsign = string.gsub(shortcallsign, callsignroot, self.callsignTranslations[callsignroot])
-    end
-  
     local groupname = Group:GetName()
     local callnumber = string.match(shortcallsign, "(%d+)$" ) or "unknown11"
     local callnumbermajor = string.char(string.byte(callnumber,1))
@@ -1973,7 +1951,6 @@ function AWACS:_GetCallSign(Group,GID)
     end
     self:T("Generated Callsign for TTS = " .. callsign)
   end
-  env.info('DEBUG: '..callsign)
   return callsign
 end
 

--- a/Moose Development/Moose/Ops/Awacs.lua
+++ b/Moose Development/Moose/Ops/Awacs.lua
@@ -252,6 +252,14 @@ do
 --            testawacs:SetAwacsDetails(CALLSIGN.AWACS.Wizard)
 --            -- And start as GCI using a group name "Blue EWR" as main EWR station
 --            testawacs:SetAsGCI(GROUP:FindByName("Blue EWR"),2)
+--            -- Set Custom Callsigns for use with TTS
+--            testawacs:SetCustomCallsigns({
+--              Devil = 'Bengal',
+--              Snake = 'Winder',
+--              Colt = 'Camelot',
+--              Enfield = 'Victory',
+--              Uzi = 'Evil Eye'
+--            })
 --            testawacs:__Start(4)
 --            
 -- ## 6 Menu entries
@@ -946,6 +954,7 @@ function AWACS:New(Name,AirWing,Coalition,AirbaseName,AwacsOrbit,OpsZone,Station
   -- managed groups
   self.ManagedGrps = {} -- #table of #AWACS.ManagedGroup entries
   self.ManagedGrpID = 0  
+  self.callsignTranslations = nil
   
   -- Anchor stacks init
   self.AnchorStacks = FIFO:New() -- Utilities.FiFo#FIFO
@@ -962,7 +971,7 @@ function AWACS:New(Name,AirWing,Coalition,AirbaseName,AwacsOrbit,OpsZone,Station
   -- Task lists
   self.ManagedTasks = FIFO:New() -- Utilities.FiFo#FIFO
   --self.OpenTasks = FIFO:New() -- Utilities.FiFo#FIFO
-  
+
   -- Monitoring, init
   local MonitoringData = {} -- #AWACS.MonitoringData
   MonitoringData.AICAPCurrent = 0
@@ -1265,6 +1274,14 @@ function AWACS:ZipLip()
   --self.NoGroupTags = true
   self.NoMissileCalls = true
   return self
+end
+
+--- [User] Do not show messages on screen
+-- @param #AWACS self
+-- @param #table table with DCS callsigns as keys and replacements as values
+-- @return #AWACS self
+function AWACS:SetCustomCallsigns(translationTable) 
+  self.callsignTranslations = translationTable
 end
 
 --- [Internal] Event handler
@@ -1936,6 +1953,11 @@ function AWACS:_GetCallSign(Group,GID)
   local callsign = "Ghost 1"
   if Group and Group:IsAlive() then
     local shortcallsign = Group:GetCallsign() or "unknown11"-- e.g.Uzi11, but we want Uzi 1 1
+    local callsignroot = string.match(shortcallsign, '(%a+)')
+    if self.callsignTranslations[callsignroot] then
+      shortcallsign = string.gsub(shortcallsign, callsignroot, self.callsignTranslations[callsignroot])
+    end
+  
     local groupname = Group:GetName()
     local callnumber = string.match(shortcallsign, "(%d+)$" ) or "unknown11"
     local callnumbermajor = string.char(string.byte(callnumber,1))
@@ -1951,6 +1973,7 @@ function AWACS:_GetCallSign(Group,GID)
     end
     self:T("Generated Callsign for TTS = " .. callsign)
   end
+  env.info('DEBUG: '..callsign)
   return callsign
 end
 


### PR DESCRIPTION
Added the ability to override DCS callsigns for purposes of TTS

Example usage:

```lua
testawacs:SetCustomCallsigns({
    Devil = 'Bengal',
    Snake = 'Winder',
    Colt = 'Camelot',
    Enfield = 'Victory',
    Uzi = 'Evil Eye'
})
```
This will replace ME callsigns with user-defined equivalents for use with the AWACS TTS and messaging only.