### PR TITLE
Range fix issue #1753

### DIFF
--- a/Moose Development/Moose/Functional/Range.lua
+++ b/Moose Development/Moose/Functional/Range.lua
@@ -1388,7 +1388,7 @@ function RANGE:AddBombingTargets( targetnames, goodhitrange, randommove )
     elseif _isstatic == false then
       local _unit = UNIT:FindByName( name )
       self:T2( self.id .. string.format( "Adding unit bombing target %s with hit range %d.", name, goodhitrange, randommove ) )
-      self:AddBombingTargetUnit( _unit, goodhitrange )
+      self:AddBombingTargetUnit( _unit, goodhitrange, randommove )
     else
       self:E( self.id .. string.format( "ERROR! Could not find bombing target %s.", name ) )
     end


### PR DESCRIPTION
Issue #1753 - when using `AddBombingTargets` the randommove flag was not passed to `AddBombingTargetUnit` for a group object