### PR TITLE
#OPSGROUP - Ground Grp always teleports fix

### DIFF
--- a/Moose Development/Moose/Ops/OpsGroup.lua
+++ b/Moose Development/Moose/Ops/OpsGroup.lua
@@ -5701,7 +5701,7 @@ function OPSGROUP:RouteToMission(mission, delay)
     end
     
     -- Check if group is mobile. Note that some immobile units report a speed of 1 m/s = 3.6 km/h.
-    if self.speedMax<=3.6 or mission.teleport then
+    if (self.speedMax<=3.6 and mission.teleport) or mission.teleport then
 
       -- Teleport to waypoint coordinate. Mission will not be paused.
       self:Teleport(waypointcoord, nil, true)


### PR DESCRIPTION
Changed line 5704 to `if (self.speedMax<=3.6 and mission.teleport) or mission.teleport then`