### PR TITLE
Make AWACS SRS talk as own coalition; Typo

### DIFF
--- a/Moose Development/Moose/Ops/Awacs.lua
+++ b/Moose Development/Moose/Ops/Awacs.lua
@@ -327,7 +327,7 @@ do
 -- * @{#AWACS.SetRadarBlur}() : Set the radar blur faktor in percent.
 -- * @{#AWACS.SetColdWar}() : Set to cold war - no fill-ins, no EPLRS, VID as standard.
 -- * @{#AWACS.SetModernEraDefensive}() : Set to modern, EPLRS, BVR/IFF engagement, fill-ins.
--- * @{#AWACS.SetModernEraAgressive}() : Set to modern, EPLRS, BVR/IFF engagement, fill-ins.
+-- * @{#AWACS.SetModernEraAggressive}() : Set to modern, EPLRS, BVR/IFF engagement, fill-ins.
 -- * @{#AWACS.SetPolicingModern}() : Set to modern, EPLRS, VID engagement, fill-ins.
 -- * @{#AWACS.SetPolicingColdWar}() : Set to cold war, no EPLRS, VID engagement, no fill-ins.
 -- * @{#AWACS.SetInterceptTimeline}() : Set distances for TAC, Meld and Threat range calls.
@@ -1714,7 +1714,7 @@ end
 --- [User] Set AWACS to Modern Era standards - ROE to BVR, ROT to return fire. Radar blur 15%.
 -- @param #AWACS self
 -- @return #AWACS self
-function AWACS:SetModernEraAgressive()
+function AWACS:SetModernEraAggressive()
   self.ModernEra = true
   self.AwacsROT = AWACS.ROT.RETURNFIRE
   self.AwacsROE = AWACS.ROE.BVR

--- a/Moose Development/Moose/Ops/Awacs.lua
+++ b/Moose Development/Moose/Ops/Awacs.lua
@@ -1900,6 +1900,7 @@ function AWACS:SetSRS(PathToSRS,Gender,Culture,Port,Voice,Volume,PathToGoogleKey
   self.Volume = Volume or 1.0
   
   self.AwacsSRS = MSRS:New(self.PathToSRS,self.MultiFrequency,self.MultiModulation,self.Volume)
+  self.AwacsSRS:SetCoalition(self.coalition)
   self.AwacsSRS:SetGender(self.Gender)
   self.AwacsSRS:SetCulture(self.Culture)
   self.AwacsSRS:SetVoice(self.Voice)


### PR DESCRIPTION
By using original source code, AWACS speaks on SRS as "neutral" speaker, forcing SRS server admin to disable the option "Secure Coalition Radios" in SRS server. This means Moose's AWACS class cannot be used in PvP environments, where each coalition could take advantage of its own AWACS.

Pulled change to source code solves this by setting MSRS object to AWACS coalition. This way BLUFOR Awacs does speak as blue coalition only to blue pilots; OPFOR Awacs does speak as red coalition only to red pilots. And, above all, class can be used in PvP environments.

Besides that, I rectified a little typo in source code in SetModernEraAgressive() function (it should have two 'g').

P.S.: I'm not very good with Github, hope I proposed pulls in the right way.