### PR TITLE
#ZONE * Fixed ZONE_RADIUS Not being added to _Database

### DIFF
--- a/Moose Development/Moose/Core/Zone.lua
+++ b/Moose Development/Moose/Core/Zone.lua
@@ -631,11 +631,9 @@ ZONE_RADIUS = {
 -- @param #string ZoneName Name of the zone.
 -- @param DCS#Vec2 Vec2 The location of the zone.
 -- @param DCS#Distance Radius The radius of the zone.
--- @param DCS#RegisterZone Registers the Zone in the _Database Table. Default=true
+-- @param DCS#Boolean DoNotRegisterZone Determins if the Zone should not be registered in the _Database Table. Default=false
 -- @return #ZONE_RADIUS self
-function ZONE_RADIUS:New( ZoneName, Vec2, Radius, RegisterZone )
-
-   RegisterZone = RegisterZone or true
+function ZONE_RADIUS:New( ZoneName, Vec2, Radius, DoNotRegisterZone )
 
   -- Inherit ZONE_BASE.
   local self = BASE:Inherit( self, ZONE_BASE:New( ZoneName ) ) -- #ZONE_RADIUS
@@ -644,9 +642,10 @@ function ZONE_RADIUS:New( ZoneName, Vec2, Radius, RegisterZone )
   self.Radius = Radius
   self.Vec2 = Vec2
 
-  if RegisterZone then
+  if not DoNotRegisterZone then
     _EVENTDISPATCHER:CreateEventNewZone(self)
   end
+  
   --self.Coordinate=COORDINATE:NewFromVec2(Vec2)
 
   return self
@@ -1544,7 +1543,7 @@ function ZONE:New( ZoneName )
   end
 
   -- Create a new ZONE_RADIUS.
-  local self=BASE:Inherit( self, ZONE_RADIUS:New(ZoneName, {x=Zone.point.x, y=Zone.point.z}, Zone.radius, false))
+  local self=BASE:Inherit( self, ZONE_RADIUS:New(ZoneName, {x=Zone.point.x, y=Zone.point.z}, Zone.radius, true))
   self:F(ZoneName)
 
   -- Color of zone.
@@ -1611,7 +1610,7 @@ function ZONE_UNIT:New( ZoneName, ZoneUNIT, Radius, Offset)
     self.relative_to_unit = Offset.relative_to_unit or false
   end
 
-  local self = BASE:Inherit( self, ZONE_RADIUS:New( ZoneName, ZoneUNIT:GetVec2(), Radius, false ) )
+  local self = BASE:Inherit( self, ZONE_RADIUS:New( ZoneName, ZoneUNIT:GetVec2(), Radius, true ) )
 
   self:F( { ZoneName, ZoneUNIT:GetVec2(), Radius } )
 
@@ -1727,7 +1726,7 @@ ZONE_GROUP = {
 -- @param DCS#Distance Radius The radius of the zone.
 -- @return #ZONE_GROUP self
 function ZONE_GROUP:New( ZoneName, ZoneGROUP, Radius )
-  local self = BASE:Inherit( self, ZONE_RADIUS:New( ZoneName, ZoneGROUP:GetVec2(), Radius, false ) )
+  local self = BASE:Inherit( self, ZONE_RADIUS:New( ZoneName, ZoneGROUP:GetVec2(), Radius, true ) )
   self:F( { ZoneName, ZoneGROUP:GetVec2(), Radius } )
 
   self._.ZoneGROUP = ZoneGROUP
@@ -2327,7 +2326,7 @@ function ZONE_POLYGON_BASE:Boundary(Coalition, Color, Radius, Alpha, Segments, C
             for Segment = 0, Segments do
                 local PointX = self._.Polygon[i].x + ( Segment * DeltaX / Segments )
                 local PointY = self._.Polygon[i].y + ( Segment * DeltaY / Segments )
-                ZONE_RADIUS:New( "Zone", {x = PointX, y = PointY}, Radius, true ):DrawZone(Coalition, Color, 1, Color, Alpha, nil, true)
+                ZONE_RADIUS:New( "Zone", {x = PointX, y = PointY}, Radius, true ):DrawZone(Coalition, Color, 1, Color, Alpha, nil, false)
             end
         end
         j = i
@@ -2954,7 +2953,7 @@ do -- ZONE_AIRBASE
 
     local Airbase = AIRBASE:FindByName( AirbaseName )
 
-    local self = BASE:Inherit( self, ZONE_RADIUS:New( AirbaseName, Airbase:GetVec2(), Radius, false ) )
+    local self = BASE:Inherit( self, ZONE_RADIUS:New( AirbaseName, Airbase:GetVec2(), Radius, true ) )
 
     self._.ZoneAirbase = Airbase
     self._.ZoneVec2Cache = self._.ZoneAirbase:GetVec2()

--- a/Moose Development/Moose/Core/Zone.lua
+++ b/Moose Development/Moose/Core/Zone.lua
@@ -631,8 +631,11 @@ ZONE_RADIUS = {
 -- @param #string ZoneName Name of the zone.
 -- @param DCS#Vec2 Vec2 The location of the zone.
 -- @param DCS#Distance Radius The radius of the zone.
+-- @param DCS#RegisterZone Registers the Zone in the _Database Table. Default=true
 -- @return #ZONE_RADIUS self
-function ZONE_RADIUS:New( ZoneName, Vec2, Radius )
+function ZONE_RADIUS:New( ZoneName, Vec2, Radius, RegisterZone )
+
+   RegisterZone = RegisterZone or true
 
   -- Inherit ZONE_BASE.
   local self = BASE:Inherit( self, ZONE_BASE:New( ZoneName ) ) -- #ZONE_RADIUS
@@ -641,6 +644,9 @@ function ZONE_RADIUS:New( ZoneName, Vec2, Radius )
   self.Radius = Radius
   self.Vec2 = Vec2
 
+  if RegisterZone then
+    _EVENTDISPATCHER:CreateEventNewZone(self)
+  end
   --self.Coordinate=COORDINATE:NewFromVec2(Vec2)
 
   return self
@@ -1538,7 +1544,7 @@ function ZONE:New( ZoneName )
   end
 
   -- Create a new ZONE_RADIUS.
-  local self=BASE:Inherit( self, ZONE_RADIUS:New(ZoneName, {x=Zone.point.x, y=Zone.point.z}, Zone.radius))
+  local self=BASE:Inherit( self, ZONE_RADIUS:New(ZoneName, {x=Zone.point.x, y=Zone.point.z}, Zone.radius, false))
   self:F(ZoneName)
 
   -- Color of zone.
@@ -1605,7 +1611,7 @@ function ZONE_UNIT:New( ZoneName, ZoneUNIT, Radius, Offset)
     self.relative_to_unit = Offset.relative_to_unit or false
   end
 
-  local self = BASE:Inherit( self, ZONE_RADIUS:New( ZoneName, ZoneUNIT:GetVec2(), Radius ) )
+  local self = BASE:Inherit( self, ZONE_RADIUS:New( ZoneName, ZoneUNIT:GetVec2(), Radius, false ) )
 
   self:F( { ZoneName, ZoneUNIT:GetVec2(), Radius } )
 
@@ -1721,7 +1727,7 @@ ZONE_GROUP = {
 -- @param DCS#Distance Radius The radius of the zone.
 -- @return #ZONE_GROUP self
 function ZONE_GROUP:New( ZoneName, ZoneGROUP, Radius )
-  local self = BASE:Inherit( self, ZONE_RADIUS:New( ZoneName, ZoneGROUP:GetVec2(), Radius ) )
+  local self = BASE:Inherit( self, ZONE_RADIUS:New( ZoneName, ZoneGROUP:GetVec2(), Radius, false ) )
   self:F( { ZoneName, ZoneGROUP:GetVec2(), Radius } )
 
   self._.ZoneGROUP = ZoneGROUP
@@ -2321,7 +2327,7 @@ function ZONE_POLYGON_BASE:Boundary(Coalition, Color, Radius, Alpha, Segments, C
             for Segment = 0, Segments do
                 local PointX = self._.Polygon[i].x + ( Segment * DeltaX / Segments )
                 local PointY = self._.Polygon[i].y + ( Segment * DeltaY / Segments )
-                ZONE_RADIUS:New( "Zone", {x = PointX, y = PointY}, Radius ):DrawZone(Coalition, Color, 1, Color, Alpha, nil, true)
+                ZONE_RADIUS:New( "Zone", {x = PointX, y = PointY}, Radius, true ):DrawZone(Coalition, Color, 1, Color, Alpha, nil, true)
             end
         end
         j = i
@@ -2948,7 +2954,7 @@ do -- ZONE_AIRBASE
 
     local Airbase = AIRBASE:FindByName( AirbaseName )
 
-    local self = BASE:Inherit( self, ZONE_RADIUS:New( AirbaseName, Airbase:GetVec2(), Radius ) )
+    local self = BASE:Inherit( self, ZONE_RADIUS:New( AirbaseName, Airbase:GetVec2(), Radius, false ) )
 
     self._.ZoneAirbase = Airbase
     self._.ZoneVec2Cache = self._.ZoneAirbase:GetVec2()


### PR DESCRIPTION
Bugfix for #1797.

ZONE_RADIUS was not being registered within the _Database table, thus for CTLD, the Zone could not be found for a couple of functions that would search through the _Database for the zone. 

Because other Zone types inherit ZONE_RADIUS, I've added a RegisterZone parameter that is default to true, and modified the inheritance of the other Zone types to register the zone in the _Database depending if the zone does not get registered in that zone type's creation.