### PR TITLE
Documentation fixes.

### DIFF
--- a/Moose Development/Moose/AI/AI_A2A_Cap.lua
+++ b/Moose Development/Moose/AI/AI_A2A_Cap.lua
@@ -15,7 +15,7 @@
 -- @extends AI.AI_Air_Patrol#AI_AIR_PATROL
 -- @extends AI.AI_Air_Engage#AI_AIR_ENGAGE
 
---- The AI_A2A_CAP class implements the core functions to patrol a @{Zone} by an AI @{Wrapper.Group} or @{Wrapper.Group}
+--- The AI_A2A_CAP class implements the core functions to patrol a @{Core.Zone} by an AI @{Wrapper.Group} or @{Wrapper.Group}
 -- and automatically engage any airborne enemies that are within a certain range or within a certain zone.
 --
 -- ![Process](..\Presentations\AI_CAP\Dia3.JPG)
@@ -88,7 +88,7 @@
 --
 -- ![Zone](..\Presentations\AI_CAP\Dia12.JPG)
 --
--- An optional @{Zone} can be set,
+-- An optional @{Core.Zone} can be set,
 -- that will define when the AI will engage with the detected airborne enemy targets.
 -- Use the method @{#AI_A2A_CAP.SetEngageZone}() to define that Zone.
 --
@@ -107,7 +107,7 @@ AI_A2A_CAP = {
 -- @param DCS#Altitude EngageFloorAltitude The lowest altitude in meters where to execute the engagement.
 -- @param DCS#Altitude EngageCeilingAltitude The highest altitude in meters where to execute the engagement.
 -- @param DCS#AltitudeType EngageAltType The altitude type ("RADIO"=="AGL", "BARO"=="ASL"). Defaults to "RADIO".
--- @param Core.Zone#ZONE_BASE PatrolZone The @{Zone} where the patrol needs to be executed.
+-- @param Core.Zone#ZONE_BASE PatrolZone The @{Core.Zone} where the patrol needs to be executed.
 -- @param DCS#Speed  PatrolMinSpeed The minimum speed of the @{Wrapper.Group} in km/h.
 -- @param DCS#Speed  PatrolMaxSpeed The maximum speed of the @{Wrapper.Group} in km/h.
 -- @param DCS#Altitude PatrolFloorAltitude The lowest altitude in meters where to execute the patrol.
@@ -133,7 +133,7 @@ end
 --- Creates a new AI_A2A_CAP object
 -- @param #AI_A2A_CAP self
 -- @param Wrapper.Group#GROUP AICap
--- @param Core.Zone#ZONE_BASE PatrolZone The @{Zone} where the patrol needs to be executed.
+-- @param Core.Zone#ZONE_BASE PatrolZone The @{Core.Zone} where the patrol needs to be executed.
 -- @param DCS#Altitude PatrolFloorAltitude The lowest altitude in meters where to execute the patrol.
 -- @param DCS#Altitude PatrolCeilingAltitude The highest altitude in meters where to execute the patrol.
 -- @param DCS#Speed  PatrolMinSpeed The minimum speed of the @{Wrapper.Group} in km/h.

--- a/Moose Development/Moose/AI/AI_A2A_Dispatcher.lua
+++ b/Moose Development/Moose/AI/AI_A2A_Dispatcher.lua
@@ -126,7 +126,7 @@
 --    * polygon zones
 --    * moving zones
 --
--- Depending on the type of zone selected, a different @{Zone} object needs to be created from a ZONE_ class.
+-- Depending on the type of zone selected, a different @{Core.Zone} object needs to be created from a ZONE_ class.
 --
 -- ## 14. For each Squadron doing CAP, what are the time intervals and CAP amounts to be performed?
 --
@@ -356,7 +356,7 @@ do -- AI_A2A_DISPATCHER
   --
   -- ![Banner Image](..\Presentations\AI_A2A_DISPATCHER\Dia9.JPG)
   --
-  -- If it's a cold war then the **borders of red and blue territory** need to be defined using a @{zone} object derived from @{Core.Zone#ZONE_BASE}.
+  -- If it's a cold war then the **borders of red and blue territory** need to be defined using a @{Core.Zone} object derived from @{Core.Zone#ZONE_BASE}.
   -- If a hot war is chosen then **no borders** actually need to be defined using the helicopter units other than
   -- it makes it easier sometimes for the mission maker to envisage where the red and blue territories roughly are.
   -- In a hot war the borders are effectively defined by the ground based radar coverage of a coalition.
@@ -592,7 +592,7 @@ do -- AI_A2A_DISPATCHER
   --      A2ADispatcher:SetSquadronCap( "Maykop", CAPZoneMiddle, 4000, 8000, 600, 800, 800, 1200, "RADIO" )
   --      A2ADispatcher:SetSquadronCapInterval( "Sochi", 2, 30, 120, 1 )
   --
-  -- Note the different @{Zone} MOOSE classes being used to create zones of different types. Please click the @{Zone} link for more information about the different zone types.
+  -- Note the different @{Core.Zone} MOOSE classes being used to create zones of different types. Please click the @{Core.Zone} link for more information about the different zone types.
   -- Zones can be circles, can be setup in the mission editor using trigger zones, but can also be setup in the mission editor as polygons and in this case GROUP objects are being used!
   --
   -- ## 7.2. Set the squadron to execute CAP:
@@ -1304,7 +1304,7 @@ do -- AI_A2A_DISPATCHER
   --- Define a border area to simulate a **cold war** scenario.
   -- A **cold war** is one where CAP aircraft patrol their territory but will not attack enemy aircraft or launch GCI aircraft unless enemy aircraft enter their territory. In other words the EWR may detect an enemy aircraft but will only send aircraft to attack it if it crosses the border.
   -- A **hot war** is one where CAP aircraft will intercept any detected enemy aircraft and GCI aircraft will launch against detected enemy aircraft without regard for territory. In other words if the ground radar can detect the enemy aircraft then it will send CAP and GCI aircraft to attack it.
-  -- If it's a cold war then the **borders of red and blue territory** need to be defined using a @{zone} object derived from @{Core.Zone#ZONE_BASE}. This method needs to be used for this.
+  -- If it's a cold war then the **borders of red and blue territory** need to be defined using a @{Core.Zone} object derived from @{Core.Zone#ZONE_BASE}. This method needs to be used for this.
   -- If a hot war is chosen then **no borders** actually need to be defined using the helicopter units other than it makes it easier sometimes for the mission maker to envisage where the red and blue territories roughly are. In a hot war the borders are effectively defined by the ground based radar coverage of a coalition. Set the noborders parameter to 1
   -- @param #AI_A2A_DISPATCHER self
   -- @param Core.Zone#ZONE_BASE BorderZone An object derived from ZONE_BASE, or a list of objects derived from ZONE_BASE.
@@ -1713,7 +1713,7 @@ do -- AI_A2A_DISPATCHER
     -- Get free parking for fighter aircraft.
     local nfreeparking = DefenderSquadron.Airbase:GetFreeParkingSpotsNumber( AIRBASE.TerminalType.FighterAircraft, true )
 
-    -- Take number of free parking spots if no resource count was specifed.
+    -- Take number of free parking spots if no resource count was specified.
     DefenderSquadron.ResourceCount = DefenderSquadron.ResourceCount or nfreeparking
 
     -- Check that resource count is not larger than free parking spots.
@@ -1758,7 +1758,7 @@ do -- AI_A2A_DISPATCHER
   -- @param DCS#Altitude EngageFloorAltitude The lowest altitude in meters where to execute the engagement.
   -- @param DCS#Altitude EngageCeilingAltitude The highest altitude in meters where to execute the engagement.
   -- @param #number EngageAltType The altitude type to engage, which is a string "BARO" defining Barometric or "RADIO" defining radio controlled altitude.
-  -- @param Core.Zone#ZONE_BASE Zone The @{Zone} object derived from @{Core.Zone#ZONE_BASE} that defines the zone wherein the CAP will be executed.
+  -- @param Core.Zone#ZONE_BASE Zone The @{Core.Zone} object derived from @{Core.Zone#ZONE_BASE} that defines the zone wherein the CAP will be executed.
   -- @param #number PatrolMinSpeed The minimum speed at which the cap can be executed.
   -- @param #number PatrolMaxSpeed The maximum speed at which the cap can be executed.
   -- @param #number PatrolFloorAltitude The minimum altitude at which the cap can be executed.
@@ -1825,7 +1825,7 @@ do -- AI_A2A_DISPATCHER
   --- Set a CAP for a Squadron.
   -- @param #AI_A2A_DISPATCHER self
   -- @param #string SquadronName The squadron name.
-  -- @param Core.Zone#ZONE_BASE Zone The @{Zone} object derived from @{Core.Zone#ZONE_BASE} that defines the zone wherein the CAP will be executed.
+  -- @param Core.Zone#ZONE_BASE Zone The @{Core.Zone} object derived from @{Core.Zone#ZONE_BASE} that defines the zone wherein the CAP will be executed.
   -- @param #number PatrolFloorAltitude The minimum altitude at which the cap can be executed.
   -- @param #number PatrolCeilingAltitude the maximum altitude at which the cap can be executed.
   -- @param #number PatrolMinSpeed The minimum speed at which the cap can be executed.

--- a/Moose Development/Moose/AI/AI_A2A_Gci.lua
+++ b/Moose Development/Moose/AI/AI_A2A_Gci.lua
@@ -89,7 +89,7 @@
 --
 -- ![Zone](..\Presentations\AI_GCI\Dia12.JPG)
 --
--- An optional @{Zone} can be set,
+-- An optional @{Core.Zone} can be set,
 -- that will define when the AI will engage with the detected airborne enemy targets.
 -- Use the method @{AI.AI_CAP#AI_CAP_ZONE.SetEngageZone}() to define that Zone.
 --

--- a/Moose Development/Moose/AI/AI_A2A_Patrol.lua
+++ b/Moose Development/Moose/AI/AI_A2A_Patrol.lua
@@ -13,7 +13,7 @@
 --- @type AI_A2A_PATROL
 -- @extends AI.AI_A2A#AI_A2A
 
---- Implements the core functions to patrol a @{Zone} by an AI @{Wrapper.Group} or @{Wrapper.Group}.
+--- Implements the core functions to patrol a @{Core.Zone} by an AI @{Wrapper.Group} or @{Wrapper.Group}.
 -- 
 -- ![Process](..\Presentations\AI_PATROL\Dia3.JPG)
 -- 
@@ -122,7 +122,7 @@ AI_A2A_PATROL = {
 --- Creates a new AI_A2A_PATROL object
 -- @param #AI_A2A_PATROL self
 -- @param Wrapper.Group#GROUP AIPatrol The patrol group object.
--- @param Core.Zone#ZONE_BASE PatrolZone The @{Zone} where the patrol needs to be executed.
+-- @param Core.Zone#ZONE_BASE PatrolZone The @{Core.Zone} where the patrol needs to be executed.
 -- @param DCS#Altitude PatrolFloorAltitude The lowest altitude in meters where to execute the patrol.
 -- @param DCS#Altitude PatrolCeilingAltitude The highest altitude in meters where to execute the patrol.
 -- @param DCS#Speed  PatrolMinSpeed The minimum speed of the @{Wrapper.Group} in km/h.

--- a/Moose Development/Moose/AI/AI_A2G_BAI.lua
+++ b/Moose Development/Moose/AI/AI_A2G_BAI.lua
@@ -31,7 +31,7 @@ AI_A2G_BAI = {
 -- @param DCS#Altitude EngageFloorAltitude The lowest altitude in meters where to execute the engagement.
 -- @param DCS#Altitude EngageCeilingAltitude The highest altitude in meters where to execute the engagement.
 -- @param DCS#AltitudeType EngageAltType The altitude type ("RADIO"=="AGL", "BARO"=="ASL"). Defaults to "RADIO".
--- @param Core.Zone#ZONE_BASE PatrolZone The @{Zone} where the patrol needs to be executed.
+-- @param Core.Zone#ZONE_BASE PatrolZone The @{Core.Zone} where the patrol needs to be executed.
 -- @param DCS#Altitude PatrolFloorAltitude The lowest altitude in meters where to execute the patrol.
 -- @param DCS#Altitude PatrolCeilingAltitude The highest altitude in meters where to execute the patrol.
 -- @param DCS#Speed  PatrolMinSpeed The minimum speed of the @{Wrapper.Group} in km/h.
@@ -55,7 +55,7 @@ end
 -- @param DCS#Speed  EngageMaxSpeed The maximum speed of the @{Wrapper.Group} in km/h when engaging a target.
 -- @param DCS#Altitude EngageFloorAltitude The lowest altitude in meters where to execute the engagement.
 -- @param DCS#Altitude EngageCeilingAltitude The highest altitude in meters where to execute the engagement.
--- @param Core.Zone#ZONE_BASE PatrolZone The @{Zone} where the patrol needs to be executed.
+-- @param Core.Zone#ZONE_BASE PatrolZone The @{Core.Zone} where the patrol needs to be executed.
 -- @param DCS#Altitude PatrolFloorAltitude The lowest altitude in meters where to execute the patrol.
 -- @param DCS#Altitude PatrolCeilingAltitude The highest altitude in meters where to execute the patrol.
 -- @param DCS#Speed  PatrolMinSpeed The minimum speed of the @{Wrapper.Group} in km/h.

--- a/Moose Development/Moose/AI/AI_A2G_CAS.lua
+++ b/Moose Development/Moose/AI/AI_A2G_CAS.lua
@@ -31,7 +31,7 @@ AI_A2G_CAS = {
 -- @param DCS#Altitude EngageFloorAltitude The lowest altitude in meters where to execute the engagement.
 -- @param DCS#Altitude EngageCeilingAltitude The highest altitude in meters where to execute the engagement.
 -- @param DCS#AltitudeType EngageAltType The altitude type ("RADIO"=="AGL", "BARO"=="ASL"). Defaults to "RADIO".
--- @param Core.Zone#ZONE_BASE PatrolZone The @{Zone} where the patrol needs to be executed.
+-- @param Core.Zone#ZONE_BASE PatrolZone The @{Core.Zone} where the patrol needs to be executed.
 -- @param DCS#Altitude PatrolFloorAltitude The lowest altitude in meters where to execute the patrol.
 -- @param DCS#Altitude PatrolCeilingAltitude The highest altitude in meters where to execute the patrol.
 -- @param DCS#Speed  PatrolMinSpeed The minimum speed of the @{Wrapper.Group} in km/h.
@@ -55,7 +55,7 @@ end
 -- @param DCS#Speed  EngageMaxSpeed The maximum speed of the @{Wrapper.Group} in km/h when engaging a target.
 -- @param DCS#Altitude EngageFloorAltitude The lowest altitude in meters where to execute the engagement.
 -- @param DCS#Altitude EngageCeilingAltitude The highest altitude in meters where to execute the engagement.
--- @param Core.Zone#ZONE_BASE PatrolZone The @{Zone} where the patrol needs to be executed.
+-- @param Core.Zone#ZONE_BASE PatrolZone The @{Core.Zone} where the patrol needs to be executed.
 -- @param DCS#Altitude PatrolFloorAltitude The lowest altitude in meters where to execute the patrol.
 -- @param DCS#Altitude PatrolCeilingAltitude The highest altitude in meters where to execute the patrol.
 -- @param DCS#Speed  PatrolMinSpeed The minimum speed of the @{Wrapper.Group} in km/h.

--- a/Moose Development/Moose/AI/AI_A2G_Dispatcher.lua
+++ b/Moose Development/Moose/AI/AI_A2G_Dispatcher.lua
@@ -175,7 +175,7 @@
 --    * polygon zones
 --    * moving zones
 -- 
--- Depending on the type of zone selected, a different @{Zone} object needs to be created from a ZONE_ class.
+-- Depending on the type of zone selected, a different @{Core.Zone} object needs to be created from a ZONE_ class.
 -- 
 -- 
 -- ## 12. Are moving defense coordinates possible?
@@ -1389,7 +1389,7 @@ do -- AI_A2G_DISPATCHER
   --- Define a border area to simulate a **cold war** scenario.
   -- A **cold war** is one where Patrol aircraft patrol their territory but will not attack enemy aircraft or launch GCI aircraft unless enemy aircraft enter their territory. In other words the EWR may detect an enemy aircraft but will only send aircraft to attack it if it crosses the border.
   -- A **hot war** is one where Patrol aircraft will intercept any detected enemy aircraft and GCI aircraft will launch against detected enemy aircraft without regard for territory. In other words if the ground radar can detect the enemy aircraft then it will send Patrol and GCI aircraft to attack it.
-  -- If it's a cold war then the **borders of red and blue territory** need to be defined using a @{zone} object derived from @{Core.Zone#ZONE_BASE}. This method needs to be used for this.
+  -- If it's a cold war then the **borders of red and blue territory** need to be defined using a @{Core.Zone} object derived from @{Core.Zone#ZONE_BASE}. This method needs to be used for this.
   -- If a hot war is chosen then **no borders** actually need to be defined using the helicopter units other than it makes it easier sometimes for the mission maker to envisage where the red and blue territories roughly are. In a hot war the borders are effectively defined by the ground based radar coverage of a coalition. Set the noborders parameter to 1
   -- @param #AI_A2G_DISPATCHER self
   -- @param Core.Zone#ZONE_BASE BorderZone An object derived from ZONE_BASE, or a list of objects derived from ZONE_BASE.
@@ -2185,7 +2185,7 @@ do -- AI_A2G_DISPATCHER
   -- The Sead patrol will start a patrol of the aircraft at a specified zone, and will engage when commanded.
   -- @param #AI_A2G_DISPATCHER self
   -- @param #string SquadronName The squadron name.
-  -- @param Core.Zone#ZONE_BASE Zone The @{Zone} object derived from @{Core.Zone#ZONE_BASE} that defines the zone wherein the Patrol will be executed.
+  -- @param Core.Zone#ZONE_BASE Zone The @{Core.Zone} object derived from @{Core.Zone#ZONE_BASE} that defines the zone wherein the Patrol will be executed.
   -- @param #number PatrolMinSpeed (optional, default = 50% of max speed) The minimum speed at which the cap can be executed.
   -- @param #number PatrolMaxSpeed (optional, default = 75% of max speed) The maximum speed at which the cap can be executed.
   -- @param #number PatrolFloorAltitude (optional, default = 1000m ) The minimum altitude at which the cap can be executed.
@@ -2234,7 +2234,7 @@ do -- AI_A2G_DISPATCHER
   -- The Sead patrol will start a patrol of the aircraft at a specified zone, and will engage when commanded.
   -- @param #AI_A2G_DISPATCHER self
   -- @param #string SquadronName The squadron name.
-  -- @param Core.Zone#ZONE_BASE Zone The @{Zone} object derived from @{Core.Zone#ZONE_BASE} that defines the zone wherein the Patrol will be executed.
+  -- @param Core.Zone#ZONE_BASE Zone The @{Core.Zone} object derived from @{Core.Zone#ZONE_BASE} that defines the zone wherein the Patrol will be executed.
   -- @param #number FloorAltitude (optional, default = 1000m ) The minimum altitude at which the cap can be executed.
   -- @param #number CeilingAltitude (optional, default = 1500m ) The maximum altitude at which the cap can be executed.
   -- @param #number PatrolMinSpeed (optional, default = 50% of max speed) The minimum speed at which the cap can be executed.
@@ -2336,7 +2336,7 @@ do -- AI_A2G_DISPATCHER
   -- The Cas patrol will start a patrol of the aircraft at a specified zone, and will engage when commanded.
   -- @param #AI_A2G_DISPATCHER self
   -- @param #string SquadronName The squadron name.
-  -- @param Core.Zone#ZONE_BASE Zone The @{Zone} object derived from @{Core.Zone#ZONE_BASE} that defines the zone wherein the Patrol will be executed.
+  -- @param Core.Zone#ZONE_BASE Zone The @{Core.Zone} object derived from @{Core.Zone#ZONE_BASE} that defines the zone wherein the Patrol will be executed.
   -- @param #number PatrolMinSpeed (optional, default = 50% of max speed) The minimum speed at which the cap can be executed.
   -- @param #number PatrolMaxSpeed (optional, default = 75% of max speed) The maximum speed at which the cap can be executed.
   -- @param #number PatrolFloorAltitude (optional, default = 1000m ) The minimum altitude at which the cap can be executed.
@@ -2385,7 +2385,7 @@ do -- AI_A2G_DISPATCHER
   -- The Cas patrol will start a patrol of the aircraft at a specified zone, and will engage when commanded.
   -- @param #AI_A2G_DISPATCHER self
   -- @param #string SquadronName The squadron name.
-  -- @param Core.Zone#ZONE_BASE Zone The @{Zone} object derived from @{Core.Zone#ZONE_BASE} that defines the zone wherein the Patrol will be executed.
+  -- @param Core.Zone#ZONE_BASE Zone The @{Core.Zone} object derived from @{Core.Zone#ZONE_BASE} that defines the zone wherein the Patrol will be executed.
   -- @param #number FloorAltitude (optional, default = 1000m ) The minimum altitude at which the cap can be executed.
   -- @param #number CeilingAltitude (optional, default = 1500m ) The maximum altitude at which the cap can be executed.
   -- @param #number PatrolMinSpeed (optional, default = 50% of max speed) The minimum speed at which the cap can be executed.
@@ -2487,7 +2487,7 @@ do -- AI_A2G_DISPATCHER
   -- The Bai patrol will start a patrol of the aircraft at a specified zone, and will engage when commanded.
   -- @param #AI_A2G_DISPATCHER self
   -- @param #string SquadronName The squadron name.
-  -- @param Core.Zone#ZONE_BASE Zone The @{Zone} object derived from @{Core.Zone#ZONE_BASE} that defines the zone wherein the Patrol will be executed.
+  -- @param Core.Zone#ZONE_BASE Zone The @{Core.Zone} object derived from @{Core.Zone#ZONE_BASE} that defines the zone wherein the Patrol will be executed.
   -- @param #number PatrolMinSpeed (optional, default = 50% of max speed) The minimum speed at which the cap can be executed.
   -- @param #number PatrolMaxSpeed (optional, default = 75% of max speed) The maximum speed at which the cap can be executed.
   -- @param #number PatrolFloorAltitude (optional, default = 1000m ) The minimum altitude at which the cap can be executed.
@@ -2536,7 +2536,7 @@ do -- AI_A2G_DISPATCHER
   -- The Bai patrol will start a patrol of the aircraft at a specified zone, and will engage when commanded.
   -- @param #AI_A2G_DISPATCHER self
   -- @param #string SquadronName The squadron name.
-  -- @param Core.Zone#ZONE_BASE Zone The @{Zone} object derived from @{Core.Zone#ZONE_BASE} that defines the zone wherein the Patrol will be executed.
+  -- @param Core.Zone#ZONE_BASE Zone The @{Core.Zone} object derived from @{Core.Zone#ZONE_BASE} that defines the zone wherein the Patrol will be executed.
   -- @param #number FloorAltitude (optional, default = 1000m ) The minimum altitude at which the cap can be executed.
   -- @param #number CeilingAltitude (optional, default = 1500m ) The maximum altitude at which the cap can be executed.
   -- @param #number PatrolMinSpeed (optional, default = 50% of max speed) The minimum speed at which the cap can be executed.

--- a/Moose Development/Moose/AI/AI_A2G_SEAD.lua
+++ b/Moose Development/Moose/AI/AI_A2G_SEAD.lua
@@ -65,7 +65,7 @@
 -- 
 -- ![Zone](..\Presentations\AI_GCI\Dia12.JPG)
 -- 
--- An optional @{Zone} can be set, 
+-- An optional @{Core.Zone} can be set, 
 -- that will define when the AI will engage with the detected airborne enemy targets.
 -- Use the method @{AI.AI_CAP#AI_CAP_ZONE.SetEngageZone}() to define that Zone. -- TODO: Documentation. Check that this is actually correct. The originally referenced class does not exist.
 --  
@@ -84,7 +84,7 @@ AI_A2G_SEAD = {
 -- @param DCS#Altitude EngageFloorAltitude The lowest altitude in meters where to execute the engagement.
 -- @param DCS#Altitude EngageCeilingAltitude The highest altitude in meters where to execute the engagement.
 -- @param DCS#AltitudeType EngageAltType The altitude type ("RADIO"=="AGL", "BARO"=="ASL"). Defaults to "RADIO".
--- @param Core.Zone#ZONE_BASE PatrolZone The @{Zone} where the patrol needs to be executed.
+-- @param Core.Zone#ZONE_BASE PatrolZone The @{Core.Zone} where the patrol needs to be executed.
 -- @param DCS#Altitude PatrolFloorAltitude The lowest altitude in meters where to execute the patrol.
 -- @param DCS#Altitude PatrolCeilingAltitude The highest altitude in meters where to execute the patrol.
 -- @param DCS#Speed  PatrolMinSpeed The minimum speed of the @{Wrapper.Group} in km/h.
@@ -109,7 +109,7 @@ end
 -- @param DCS#Speed  EngageMaxSpeed The maximum speed of the @{Wrapper.Group} in km/h when engaging a target.
 -- @param DCS#Altitude EngageFloorAltitude The lowest altitude in meters where to execute the engagement.
 -- @param DCS#Altitude EngageCeilingAltitude The highest altitude in meters where to execute the engagement.
--- @param Core.Zone#ZONE_BASE PatrolZone The @{Zone} where the patrol needs to be executed.
+-- @param Core.Zone#ZONE_BASE PatrolZone The @{Core.Zone} where the patrol needs to be executed.
 -- @param DCS#Altitude PatrolFloorAltitude The lowest altitude in meters where to execute the patrol.
 -- @param DCS#Altitude PatrolCeilingAltitude The highest altitude in meters where to execute the patrol.
 -- @param DCS#Speed  PatrolMinSpeed The minimum speed of the @{Wrapper.Group} in km/h.

--- a/Moose Development/Moose/AI/AI_Air_Dispatcher.lua
+++ b/Moose Development/Moose/AI/AI_Air_Dispatcher.lua
@@ -174,7 +174,7 @@
 --    * polygon zones
 --    * moving zones
 -- 
--- Depending on the type of zone selected, a different @{Zone} object needs to be created from a ZONE_ class.
+-- Depending on the type of zone selected, a different @{Core.Zone} object needs to be created from a ZONE_ class.
 -- 
 -- 
 -- ## 12. Are moving defense coordinates possible?
@@ -1376,7 +1376,7 @@ do -- AI_AIR_DISPATCHER
   --- Define a border area to simulate a **cold war** scenario.
   -- A **cold war** is one where Patrol aircraft patrol their territory but will not attack enemy aircraft or launch GCI aircraft unless enemy aircraft enter their territory. In other words the EWR may detect an enemy aircraft but will only send aircraft to attack it if it crosses the border.
   -- A **hot war** is one where Patrol aircraft will intercept any detected enemy aircraft and GCI aircraft will launch against detected enemy aircraft without regard for territory. In other words if the ground radar can detect the enemy aircraft then it will send Patrol and GCI aircraft to attack it.
-  -- If it's a cold war then the **borders of red and blue territory** need to be defined using a @{zone} object derived from @{Core.Zone#ZONE_BASE}. This method needs to be used for this.
+  -- If it's a cold war then the **borders of red and blue territory** need to be defined using a @{Core.Zone} object derived from @{Core.Zone#ZONE_BASE}. This method needs to be used for this.
   -- If a hot war is chosen then **no borders** actually need to be defined using the helicopter units other than it makes it easier sometimes for the mission maker to envisage where the red and blue territories roughly are. In a hot war the borders are effectively defined by the ground based radar coverage of a coalition. Set the noborders parameter to 1
   -- @param #AI_AIR_DISPATCHER self
   -- @param Core.Zone#ZONE_BASE BorderZone An object derived from ZONE_BASE, or a list of objects derived from ZONE_BASE.

--- a/Moose Development/Moose/AI/AI_Air_Engage.lua
+++ b/Moose Development/Moose/AI/AI_Air_Engage.lua
@@ -65,7 +65,7 @@
 -- 
 -- ![Zone](..\Presentations\AI_GCI\Dia12.JPG)
 -- 
--- An optional @{Zone} can be set, 
+-- An optional @{Core.Zone} can be set, 
 -- that will define when the AI will engage with the detected airborne enemy targets.
 -- Use the method @{AI.AI_CAP#AI_AIR_ENGAGE.SetEngageZone}() to define that Zone.
 --  

--- a/Moose Development/Moose/AI/AI_Air_Patrol.lua
+++ b/Moose Development/Moose/AI/AI_Air_Patrol.lua
@@ -12,8 +12,7 @@
 --- @type AI_AIR_PATROL
 -- @extends AI.AI_Air#AI_AIR
 
-
---- The AI_AIR_PATROL class implements the core functions to patrol a @{Zone} by an AI @{Wrapper.Group} or @{Wrapper.Group} 
+--- The AI_AIR_PATROL class implements the core functions to patrol a @{Core.Zone} by an AI @{Wrapper.Group}
 -- and automatically engage any airborne enemies that are within a certain range or within a certain zone.
 -- 
 -- ![Process](..\Presentations\AI_CAP\Dia3.JPG)
@@ -86,7 +85,7 @@
 -- 
 -- ![Zone](..\Presentations\AI_CAP\Dia12.JPG)
 -- 
--- An optional @{Zone} can be set, 
+-- An optional @{Core.Zone} can be set, 
 -- that will define when the AI will engage with the detected airborne enemy targets.
 -- Use the method @{AI.AI_CAP#AI_AIR_PATROL.SetEngageZone}() to define that Zone.
 --  
@@ -101,7 +100,7 @@ AI_AIR_PATROL = {
 -- @param #AI_AIR_PATROL self
 -- @param AI.AI_Air#AI_AIR AI_Air The AI_AIR FSM.
 -- @param Wrapper.Group#GROUP AIGroup The AI group.
--- @param Core.Zone#ZONE_BASE PatrolZone The @{Zone} where the patrol needs to be executed.
+-- @param Core.Zone#ZONE_BASE PatrolZone The @{Core.Zone} where the patrol needs to be executed.
 -- @param DCS#Altitude PatrolFloorAltitude (optional, default = 1000m ) The lowest altitude in meters where to execute the patrol.
 -- @param DCS#Altitude PatrolCeilingAltitude (optional, default = 1500m ) The highest altitude in meters where to execute the patrol.
 -- @param DCS#Speed  PatrolMinSpeed (optional, default = 50% of max speed) The minimum speed of the @{Wrapper.Group} in km/h.
@@ -114,17 +113,17 @@ function AI_AIR_PATROL:New( AI_Air, AIGroup, PatrolZone, PatrolFloorAltitude, Pa
   local self = BASE:Inherit( self, AI_Air ) -- #AI_AIR_PATROL
 
   local SpeedMax = AIGroup:GetSpeedMax()
-  
+
   self.PatrolZone = PatrolZone
-  
+
   self.PatrolFloorAltitude = PatrolFloorAltitude or 1000
   self.PatrolCeilingAltitude = PatrolCeilingAltitude or 1500
   self.PatrolMinSpeed = PatrolMinSpeed or SpeedMax * 0.5
   self.PatrolMaxSpeed = PatrolMaxSpeed or SpeedMax * 0.75
-  
+
   -- defafult PatrolAltType to "RADIO" if not specified
   self.PatrolAltType = PatrolAltType or "RADIO"
-  
+
   self:AddTransition( { "Started", "Airborne", "Refuelling" }, "Patrol", "Patrolling" )
 
   --- OnBefore Transition Handler for Event Patrol.
@@ -135,7 +134,7 @@ function AI_AIR_PATROL:New( AI_Air, AIGroup, PatrolZone, PatrolFloorAltitude, Pa
   -- @param #string Event The Event string.
   -- @param #string To The To State string.
   -- @return #boolean Return false to cancel Transition.
-  
+
   --- OnAfter Transition Handler for Event Patrol.
   -- @function [parent=#AI_AIR_PATROL] OnAfterPatrol
   -- @param #AI_AIR_PATROL self
@@ -143,16 +142,16 @@ function AI_AIR_PATROL:New( AI_Air, AIGroup, PatrolZone, PatrolFloorAltitude, Pa
   -- @param #string From The From State string.
   -- @param #string Event The Event string.
   -- @param #string To The To State string.
-    
+
   --- Synchronous Event Trigger for Event Patrol.
   -- @function [parent=#AI_AIR_PATROL] Patrol
   -- @param #AI_AIR_PATROL self
-  
+
   --- Asynchronous Event Trigger for Event Patrol.
   -- @function [parent=#AI_AIR_PATROL] __Patrol
   -- @param #AI_AIR_PATROL self
   -- @param #number Delay The delay in seconds.
-  
+
   --- OnLeave Transition Handler for State Patrolling.
   -- @function [parent=#AI_AIR_PATROL] OnLeavePatrolling
   -- @param #AI_AIR_PATROL self
@@ -161,7 +160,7 @@ function AI_AIR_PATROL:New( AI_Air, AIGroup, PatrolZone, PatrolFloorAltitude, Pa
   -- @param #string Event The Event string.
   -- @param #string To The To State string.
   -- @return #boolean Return false to cancel Transition.
-  
+
   --- OnEnter Transition Handler for State Patrolling.
   -- @function [parent=#AI_AIR_PATROL] OnEnterPatrolling
   -- @param #AI_AIR_PATROL self
@@ -169,9 +168,9 @@ function AI_AIR_PATROL:New( AI_Air, AIGroup, PatrolZone, PatrolFloorAltitude, Pa
   -- @param #string From The From State string.
   -- @param #string Event The Event string.
   -- @param #string To The To State string.
-  
+
     self:AddTransition( "Patrolling", "PatrolRoute", "Patrolling" ) -- FSM_CONTROLLABLE Transition for type #AI_AIR_PATROL.
-  
+
   --- OnBefore Transition Handler for Event PatrolRoute.
   -- @function [parent=#AI_AIR_PATROL] OnBeforePatrolRoute
   -- @param #AI_AIR_PATROL self
@@ -180,7 +179,7 @@ function AI_AIR_PATROL:New( AI_Air, AIGroup, PatrolZone, PatrolFloorAltitude, Pa
   -- @param #string Event The Event string.
   -- @param #string To The To State string.
   -- @return #boolean Return false to cancel Transition.
-  
+
   --- OnAfter Transition Handler for Event PatrolRoute.
   -- @function [parent=#AI_AIR_PATROL] OnAfterPatrolRoute
   -- @param #AI_AIR_PATROL self
@@ -188,22 +187,20 @@ function AI_AIR_PATROL:New( AI_Air, AIGroup, PatrolZone, PatrolFloorAltitude, Pa
   -- @param #string From The From State string.
   -- @param #string Event The Event string.
   -- @param #string To The To State string.
-    
+
   --- Synchronous Event Trigger for Event PatrolRoute.
   -- @function [parent=#AI_AIR_PATROL] PatrolRoute
   -- @param #AI_AIR_PATROL self
-  
+
   --- Asynchronous Event Trigger for Event PatrolRoute.
   -- @function [parent=#AI_AIR_PATROL] __PatrolRoute
   -- @param #AI_AIR_PATROL self
   -- @param #number Delay The delay in seconds.
 
-
   self:AddTransition( "*", "Reset", "Patrolling" ) -- FSM_CONTROLLABLE Transition for type #AI_AIR_PATROL.
 
   return self
 end
-
 
 --- Set the Engage Range when the AI will engage with airborne enemies. 
 -- @param #AI_AIR_PATROL self
@@ -230,7 +227,7 @@ end
 -- @param #table CapCoordinates Table of coordinates of first race track point. Second point is determined by leg length and heading. 
 -- @return #AI_AIR_PATROL self
 function AI_AIR_PATROL:SetRaceTrackPattern(LegMin, LegMax, HeadingMin, HeadingMax, DurationMin, DurationMax, CapCoordinates)
-  
+
   self.racetrack=true
   self.racetracklegmin=LegMin or 10000
   self.racetracklegmax=LegMax or 15000
@@ -238,16 +235,14 @@ function AI_AIR_PATROL:SetRaceTrackPattern(LegMin, LegMax, HeadingMin, HeadingMa
   self.racetrackheadingmax=HeadingMax or 180
   self.racetrackdurationmin=DurationMin
   self.racetrackdurationmax=DurationMax
-  
+
   if self.racetrackdurationmax and not self.racetrackdurationmin then
     self.racetrackdurationmin=self.racetrackdurationmax
   end
-  
+
   self.racetrackcapcoordinates=CapCoordinates
-  
+
 end
-
-
 
 --- Defines a new patrol route using the @{Process_PatrolZone} parameters and settings.
 -- @param #AI_AIR_PATROL self
@@ -262,7 +257,7 @@ function AI_AIR_PATROL:onafterPatrol( AIPatrol, From, Event, To )
   self:ClearTargetDistance()
 
   self:__PatrolRoute( self.TaskDelay )
-  
+
   AIPatrol:OnReSpawn(
     function( PatrolGroup )
       self:__Reset( self.TaskDelay )
@@ -271,7 +266,7 @@ function AI_AIR_PATROL:onafterPatrol( AIPatrol, From, Event, To )
   )
 end
 
---- This statis method is called from the route path within the last task at the last waaypoint of the AIPatrol.
+--- This static method is called from the route path within the last task at the last waypoint of the AIPatrol.
 -- Note that this method is required, as triggers the next route when patrolling for the AIPatrol.
 -- @param Wrapper.Group#GROUP AIPatrol The AI group.
 -- @param #AI_AIR_PATROL Fsm The FSM.
@@ -282,7 +277,7 @@ function AI_AIR_PATROL.___PatrolRoute( AIPatrol, Fsm )
   if AIPatrol and AIPatrol:IsAlive() then
     Fsm:PatrolRoute()
   end
-  
+
 end
 
 --- Defines a new patrol route using the @{Process_PatrolZone} parameters and settings.
@@ -300,21 +295,20 @@ function AI_AIR_PATROL:onafterPatrolRoute( AIPatrol, From, Event, To )
     return
   end
 
-  
   if AIPatrol and  AIPatrol:IsAlive() then
-    
+
     local PatrolRoute = {}
 
     --- Calculate the target route point.
-    
+
     local CurrentCoord = AIPatrol:GetCoordinate()
-    
+
     local altitude= math.random( self.PatrolFloorAltitude, self.PatrolCeilingAltitude )
-    
+
     local ToTargetCoord = self.PatrolZone:GetRandomPointVec2()
     ToTargetCoord:SetAlt( altitude )
     self:SetTargetDistance( ToTargetCoord ) -- For RTB status check
-    
+
     local ToTargetSpeed = math.random( self.PatrolMinSpeed, self.PatrolMaxSpeed )
     local speedkmh=ToTargetSpeed
 
@@ -322,31 +316,31 @@ function AI_AIR_PATROL:onafterPatrolRoute( AIPatrol, From, Event, To )
     PatrolRoute[#PatrolRoute+1] = FromWP
 
     if self.racetrack then
-      
+
       -- Random heading.
       local heading = math.random(self.racetrackheadingmin, self.racetrackheadingmax)
-      
+
       -- Random leg length.
       local leg=math.random(self.racetracklegmin, self.racetracklegmax)
-      
+
       -- Random duration if any.
       local duration = self.racetrackdurationmin
       if self.racetrackdurationmax then
         duration=math.random(self.racetrackdurationmin, self.racetrackdurationmax)
       end
-      
+
       -- CAP coordinate.
       local c0=self.PatrolZone:GetRandomCoordinate()
       if self.racetrackcapcoordinates and #self.racetrackcapcoordinates>0 then
         c0=self.racetrackcapcoordinates[math.random(#self.racetrackcapcoordinates)]
       end
-      
+
       -- Race track points.
       local c1=c0:SetAltitude(altitude) --Core.Point#COORDINATE
       local c2=c1:Translate(leg, heading):SetAltitude(altitude)
-      
+
       self:SetTargetDistance(c0) -- For RTB status check
-      
+
       -- Debug:
       self:T(string.format("Patrol zone race track: v=%.1f knots, h=%.1f ft, heading=%03d, leg=%d m, t=%s sec", UTILS.KmphToKnots(speedkmh), UTILS.MetersToFeet(altitude), heading, leg, tostring(duration)))
       --c1:MarkToAll("Race track c1")
@@ -354,39 +348,41 @@ function AI_AIR_PATROL:onafterPatrolRoute( AIPatrol, From, Event, To )
 
       -- Task to orbit.              
       local taskOrbit=AIPatrol:TaskOrbit(c1, altitude, UTILS.KmphToMps(speedkmh), c2)
-      
+
       -- Task function to redo the patrol at other random position.
       local taskPatrol=AIPatrol:TaskFunction("AI_AIR_PATROL.___PatrolRoute", self)
-      
+
       -- Controlled task with task condition.
       local taskCond=AIPatrol:TaskCondition(nil, nil, nil, nil, duration, nil)
       local taskCont=AIPatrol:TaskControlled(taskOrbit, taskCond)
-      
+
       -- Second waypoint
       PatrolRoute[2]=c1:WaypointAirTurningPoint(self.PatrolAltType, speedkmh, {taskCont, taskPatrol}, "CAP Orbit")
 
     else
-    
+
       --- Create a route point of type air.
       local ToWP = ToTargetCoord:WaypointAir(self.PatrolAltType, POINT_VEC3.RoutePointType.TurningPoint, POINT_VEC3.RoutePointAction.TurningPoint, ToTargetSpeed, true)  
       PatrolRoute[#PatrolRoute+1] = ToWP
-      
+
       local Tasks = {}
       Tasks[#Tasks+1] = AIPatrol:TaskFunction("AI_AIR_PATROL.___PatrolRoute", self)
       PatrolRoute[#PatrolRoute].task = AIPatrol:TaskCombo( Tasks )
-      
+
     end
-    
+
     AIPatrol:OptionROEReturnFire()
     AIPatrol:OptionROTEvadeFire()
-  
+
     AIPatrol:Route( PatrolRoute, self.TaskDelay )
-    
+
   end
 
 end
 
---- @param Wrapper.Group#GROUP AIPatrol
+--- Resumes the AIPatrol
+-- @param Wrapper.Group#GROUP AIPatrol
+-- @param Core.Fsm#FSM Fsm
 function AI_AIR_PATROL.Resume( AIPatrol, Fsm )
 
   AIPatrol:F( { "AI_AIR_PATROL.Resume:", AIPatrol:GetName() } )
@@ -394,5 +390,5 @@ function AI_AIR_PATROL.Resume( AIPatrol, Fsm )
     Fsm:__Reset( Fsm.TaskDelay )
     Fsm:__PatrolRoute( Fsm.TaskDelay )
   end
-  
+
 end

--- a/Moose Development/Moose/AI/AI_BAI.lua
+++ b/Moose Development/Moose/AI/AI_BAI.lua
@@ -33,10 +33,10 @@
 --- AI_BAI_ZONE class
 -- @type AI_BAI_ZONE
 -- @field Wrapper.Controllable#CONTROLLABLE AIControllable The @{Wrapper.Controllable} patrolling.
--- @field Core.Zone#ZONE_BASE TargetZone The @{Zone} where the patrol needs to be executed.
+-- @field Core.Zone#ZONE_BASE TargetZone The @{Core.Zone} where the patrol needs to be executed.
 -- @extends AI.AI_Patrol#AI_PATROL_ZONE
 
---- Implements the core functions to provide BattleGround Air Interdiction in an Engage @{Zone} by an AIR @{Wrapper.Controllable} or @{Wrapper.Group}.
+--- Implements the core functions to provide BattleGround Air Interdiction in an Engage @{Core.Zone} by an AIR @{Wrapper.Controllable} or @{Wrapper.Group}.
 -- 
 -- The AI_BAI_ZONE runs a process. It holds an AI in a Patrol Zone and when the AI is commanded to engage, it will fly to an Engage Zone.
 -- 
@@ -142,7 +142,7 @@ AI_BAI_ZONE = {
 
 --- Creates a new AI_BAI_ZONE object
 -- @param #AI_BAI_ZONE self
--- @param Core.Zone#ZONE_BASE PatrolZone The @{Zone} where the patrol needs to be executed.
+-- @param Core.Zone#ZONE_BASE PatrolZone The @{Core.Zone} where the patrol needs to be executed.
 -- @param DCS#Altitude PatrolFloorAltitude The lowest altitude in meters where to execute the patrol.
 -- @param DCS#Altitude PatrolCeilingAltitude The highest altitude in meters where to execute the patrol.
 -- @param DCS#Speed  PatrolMinSpeed The minimum speed of the @{Wrapper.Controllable} in km/h.
@@ -566,7 +566,7 @@ function AI_BAI_ZONE:onafterEngage( Controllable, From, Event, To,
 
     EngageRoute[#EngageRoute].task = Controllable:TaskCombo( AttackTasks )
 
-    --- Define a random point in the @{Zone}. The AI will fly to that point within the zone.
+    --- Define a random point in the @{Core.Zone}. The AI will fly to that point within the zone.
     
       --- Find a random 2D point in EngageZone.
     local ToTargetVec2 = self.EngageZone:GetRandomVec2()

--- a/Moose Development/Moose/AI/AI_CAP.lua
+++ b/Moose Development/Moose/AI/AI_CAP.lua
@@ -35,11 +35,11 @@
 
 --- @type AI_CAP_ZONE
 -- @field Wrapper.Controllable#CONTROLLABLE AIControllable The @{Wrapper.Controllable} patrolling.
--- @field Core.Zone#ZONE_BASE TargetZone The @{Zone} where the patrol needs to be executed.
+-- @field Core.Zone#ZONE_BASE TargetZone The @{Core.Zone} where the patrol needs to be executed.
 -- @extends AI.AI_Patrol#AI_PATROL_ZONE
 
 
---- Implements the core functions to patrol a @{Zone} by an AI @{Wrapper.Controllable} or @{Wrapper.Group} 
+--- Implements the core functions to patrol a @{Core.Zone} by an AI @{Wrapper.Controllable} or @{Wrapper.Group} 
 -- and automatically engage any airborne enemies that are within a certain range or within a certain zone.
 -- 
 -- ![Process](..\Presentations\AI_CAP\Dia3.JPG)
@@ -112,7 +112,7 @@
 -- 
 -- ![Zone](..\Presentations\AI_CAP\Dia12.JPG)
 -- 
--- An optional @{Zone} can be set, 
+-- An optional @{Core.Zone} can be set, 
 -- that will define when the AI will engage with the detected airborne enemy targets.
 -- Use the method @{#AI_CAP_ZONE.SetEngageZone}() to define that Zone.
 --  
@@ -127,7 +127,7 @@ AI_CAP_ZONE = {
 
 --- Creates a new AI_CAP_ZONE object
 -- @param #AI_CAP_ZONE self
--- @param Core.Zone#ZONE_BASE PatrolZone The @{Zone} where the patrol needs to be executed.
+-- @param Core.Zone#ZONE_BASE PatrolZone The @{Core.Zone} where the patrol needs to be executed.
 -- @param DCS#Altitude PatrolFloorAltitude The lowest altitude in meters where to execute the patrol.
 -- @param DCS#Altitude PatrolCeilingAltitude The highest altitude in meters where to execute the patrol.
 -- @param DCS#Speed  PatrolMinSpeed The minimum speed of the @{Wrapper.Controllable} in km/h.

--- a/Moose Development/Moose/AI/AI_CAS.lua
+++ b/Moose Development/Moose/AI/AI_CAS.lua
@@ -34,10 +34,10 @@
 --- AI_CAS_ZONE class
 -- @type AI_CAS_ZONE
 -- @field Wrapper.Controllable#CONTROLLABLE AIControllable The @{Wrapper.Controllable} patrolling.
--- @field Core.Zone#ZONE_BASE TargetZone The @{Zone} where the patrol needs to be executed.
+-- @field Core.Zone#ZONE_BASE TargetZone The @{Core.Zone} where the patrol needs to be executed.
 -- @extends AI.AI_Patrol#AI_PATROL_ZONE
 
---- Implements the core functions to provide Close Air Support in an Engage @{Zone} by an AIR @{Wrapper.Controllable} or @{Wrapper.Group}.
+--- Implements the core functions to provide Close Air Support in an Engage @{Core.Zone} by an AIR @{Wrapper.Controllable} or @{Wrapper.Group}.
 -- The AI_CAS_ZONE runs a process. It holds an AI in a Patrol Zone and when the AI is commanded to engage, it will fly to an Engage Zone.
 -- 
 -- ![HoldAndEngage](..\Presentations\AI_CAS\Dia3.JPG)
@@ -130,7 +130,7 @@ AI_CAS_ZONE = {
 
 --- Creates a new AI_CAS_ZONE object
 -- @param #AI_CAS_ZONE self
--- @param Core.Zone#ZONE_BASE PatrolZone The @{Zone} where the patrol needs to be executed.
+-- @param Core.Zone#ZONE_BASE PatrolZone The @{Core.Zone} where the patrol needs to be executed.
 -- @param DCS#Altitude PatrolFloorAltitude The lowest altitude in meters where to execute the patrol.
 -- @param DCS#Altitude PatrolCeilingAltitude The highest altitude in meters where to execute the patrol.
 -- @param DCS#Speed  PatrolMinSpeed The minimum speed of the @{Wrapper.Controllable} in km/h.
@@ -496,7 +496,7 @@ function AI_CAS_ZONE:onafterEngage( Controllable, From, Event, To,
     AttackTasks[#AttackTasks+1] = Controllable:TaskFunction( "AI_CAS_ZONE.EngageRoute", self )
     EngageRoute[#EngageRoute].task = Controllable:TaskCombo( AttackTasks )
 
-    --- Define a random point in the @{Zone}. The AI will fly to that point within the zone.
+    --- Define a random point in the @{Core.Zone}. The AI will fly to that point within the zone.
     
       --- Find a random 2D point in EngageZone.
     local ToTargetVec2 = self.EngageZone:GetRandomVec2()

--- a/Moose Development/Moose/AI/AI_Patrol.lua
+++ b/Moose Development/Moose/AI/AI_Patrol.lua
@@ -38,7 +38,7 @@
 --- AI_PATROL_ZONE class
 -- @type AI_PATROL_ZONE
 -- @field Wrapper.Controllable#CONTROLLABLE AIControllable The @{Wrapper.Controllable} patrolling.
--- @field Core.Zone#ZONE_BASE PatrolZone The @{Zone} where the patrol needs to be executed.
+-- @field Core.Zone#ZONE_BASE PatrolZone The @{Core.Zone} where the patrol needs to be executed.
 -- @field DCS#Altitude PatrolFloorAltitude The lowest altitude in meters where to execute the patrol.
 -- @field DCS#Altitude PatrolCeilingAltitude The highest altitude in meters where to execute the patrol.
 -- @field DCS#Speed  PatrolMinSpeed The minimum speed of the @{Wrapper.Controllable} in km/h.
@@ -46,7 +46,7 @@
 -- @field Core.Spawn#SPAWN CoordTest
 -- @extends Core.Fsm#FSM_CONTROLLABLE
 
---- Implements the core functions to patrol a @{Zone} by an AI @{Wrapper.Controllable} or @{Wrapper.Group}.
+--- Implements the core functions to patrol a @{Core.Zone} by an AI @{Wrapper.Controllable} or @{Wrapper.Group}.
 -- 
 -- ![Process](..\Presentations\AI_PATROL\Dia3.JPG)
 -- 
@@ -154,7 +154,7 @@ AI_PATROL_ZONE = {
 
 --- Creates a new AI_PATROL_ZONE object
 -- @param #AI_PATROL_ZONE self
--- @param Core.Zone#ZONE_BASE PatrolZone The @{Zone} where the patrol needs to be executed.
+-- @param Core.Zone#ZONE_BASE PatrolZone The @{Core.Zone} where the patrol needs to be executed.
 -- @param DCS#Altitude PatrolFloorAltitude The lowest altitude in meters where to execute the patrol.
 -- @param DCS#Altitude PatrolCeilingAltitude The highest altitude in meters where to execute the patrol.
 -- @param DCS#Speed  PatrolMinSpeed The minimum speed of the @{Wrapper.Controllable} in km/h.
@@ -775,7 +775,7 @@ function AI_PATROL_ZONE:onafterRoute( Controllable, From, Event, To )
     end    
     
     
-    --- Define a random point in the @{Zone}. The AI will fly to that point within the zone.
+    --- Define a random point in the @{Core.Zone}. The AI will fly to that point within the zone.
     
       --- Find a random 2D point in PatrolZone.
     local ToTargetVec2 = self.PatrolZone:GetRandomVec2()

--- a/Moose Development/Moose/Actions/Act_Account.lua
+++ b/Moose Development/Moose/Actions/Act_Account.lua
@@ -1,4 +1,4 @@
---- **Actions** - ACT_ACCOUNT_ classes **account for** (detect, count & report) various DCS events occuring on @{Wrapper.Unit}s.
+--- **Actions** - ACT_ACCOUNT_ classes **account for** (detect, count & report) various DCS events occurring on @{Wrapper.Unit}s.
 --
 -- ![Banner Image](..\Presentations\ACT_ACCOUNT\Dia1.JPG)
 --
@@ -20,7 +20,7 @@ do -- ACT_ACCOUNT
   --
   -- ### ACT_ACCOUNT States
   --
-  --   * **Asigned**: The player is assigned.
+  --   * **Assigned**: The player is assigned.
   --   * **Waiting**: Waiting for an event.
   --   * **Report**: Reporting.
   --   * **Account**: Account for an event.
@@ -104,7 +104,6 @@ do -- ACT_ACCOUNT
     self:__Wait( 1 )
   end
 
-
     --- StateMachine callback function
     -- @param #ACT_ACCOUNT self
     -- @param Wrapper.Unit#UNIT ProcessUnit
@@ -157,7 +156,6 @@ do -- ACT_ACCOUNT_DEADS
     ClassName = "ACT_ACCOUNT_DEADS",
   }
 
-
   --- Creates a new DESTROY process.
   -- @param #ACT_ACCOUNT_DEADS self
   -- @param Core.Set#SET_UNIT TargetSetUnit
@@ -194,7 +192,6 @@ do -- ACT_ACCOUNT_DEADS
     local MessageText = "Your group with assigned " .. self.TaskName .. " task has " .. Task.TargetSetUnit:GetUnitTypesText() .. " targets left to be destroyed."
     self:GetCommandCenter():MessageTypeToGroup( MessageText, ProcessUnit:GetGroup(), MESSAGE.Type.Information )
   end
-
 
   --- StateMachine callback function
   -- @param #ACT_ACCOUNT_DEADS self
@@ -269,7 +266,6 @@ do -- ACT_ACCOUNT_DEADS
       self:__NoMore( 1 )
     end
   end
-
 
   --- DCS Events
 

--- a/Moose Development/Moose/Actions/Act_Assist.lua
+++ b/Moose Development/Moose/Actions/Act_Assist.lua
@@ -50,7 +50,7 @@
 --
 -- # 1) @{#ACT_ASSIST_SMOKE_TARGETS_ZONE} class, extends @{Core.Fsm.Route#ACT_ASSIST}
 --
--- The ACT_ASSIST_SMOKE_TARGETS_ZONE class implements the core functions to smoke targets in a @{Zone}.
+-- The ACT_ASSIST_SMOKE_TARGETS_ZONE class implements the core functions to smoke targets in a @{Core.Zone}.
 -- The targets are smoked within a certain range around each target, simulating a realistic smoking behaviour.
 -- At random intervals, a new target is smoked.
 --

--- a/Moose Development/Moose/Actions/Act_Route.lua
+++ b/Moose Development/Moose/Actions/Act_Route.lua
@@ -62,7 +62,7 @@
 --
 -- # 1) @{#ACT_ROUTE_ZONE} class, extends @{Core.Fsm.Route#ACT_ROUTE}
 --
--- The ACT_ROUTE_ZONE class implements the core functions to route an AIR @{Wrapper.Controllable} player @{Wrapper.Unit} to a @{Zone}.
+-- The ACT_ROUTE_ZONE class implements the core functions to route an AIR @{Wrapper.Controllable} player @{Wrapper.Unit} to a @{Core.Zone}.
 -- The player receives on perioding times messages with the coordinates of the route to follow.
 -- Upon arrival at the zone, a confirmation of arrival is sent, and the process will be ended.
 --

--- a/Moose Development/Moose/Cargo/Cargo.lua
+++ b/Moose Development/Moose/Cargo/Cargo.lua
@@ -377,7 +377,7 @@ do -- CARGO
   -- @field #boolean Moveable This flag defines if the cargo is moveable.
   -- @field #boolean Representable This flag defines if the cargo can be represented by a DCS Unit.
   -- @field #boolean Containable This flag defines if the cargo can be contained within a DCS Unit.
-  
+
   --- Defines the core functions that defines a cargo object within MOOSE.
   -- 
   -- A cargo is a **logical object** defined that is available for transport, and has a life status within a simulation.
@@ -430,8 +430,7 @@ do -- CARGO
 
   --- @type CARGO.CargoObjects
   -- @map < #string, Wrapper.Positionable#POSITIONABLE > The alive POSITIONABLE objects representing the the cargo.
-  
-  
+
   --- CARGO Constructor. This class is an abstract class and should not be instantiated.
   -- @param #CARGO self
   -- @param #string Type
@@ -441,10 +440,10 @@ do -- CARGO
   -- @param #number NearRadius (optional)
   -- @return #CARGO
   function CARGO:New( Type, Name, Weight, LoadRadius, NearRadius ) --R2.1
-  
+
     local self = BASE:Inherit( self, FSM:New() ) -- #CARGO
     self:F( { Type, Name, Weight, LoadRadius, NearRadius } )
-    
+
     self:SetStartState( "UnLoaded" )
     self:AddTransition( { "UnLoaded", "Boarding" }, "Board", "Boarding" )
     self:AddTransition( "Boarding" , "Boarding", "Boarding" )
@@ -459,7 +458,7 @@ do -- CARGO
     self:AddTransition( "*", "Destroyed", "Destroyed" )
     self:AddTransition( "*", "Respawn", "UnLoaded" )
     self:AddTransition( "*", "Reset", "UnLoaded" )
-  
+
     self.Type = Type
     self.Name = Name
     self.Weight = Weight or 0
@@ -471,31 +470,29 @@ do -- CARGO
     self.Containable = false
 
     self.CargoLimit = 0
-    
+
     self.LoadRadius = LoadRadius or 500
     --self.NearRadius = NearRadius or 25
-    
+
     self:SetDeployed( false )
-  
+
     self.CargoScheduler = SCHEDULER:New()
-  
+
     CARGOS[self.Name] = self
-  
-    
+
     return self
   end
-  
-  
+
   --- Find a CARGO in the _DATABASE.
   -- @param #CARGO self
   -- @param #string CargoName The Cargo Name.
   -- @return #CARGO self
   function CARGO:FindByName( CargoName )
-    
+
     local CargoFound = _DATABASE:FindCargo( CargoName )
     return CargoFound
   end
-  
+
   --- Get the x position of the cargo.
   -- @param #CARGO self
   -- @return #number
@@ -504,9 +501,9 @@ do -- CARGO
       return self.CargoCarrier:GetCoordinate().x
     else
       return self.CargoObject:GetCoordinate().x
-    end 
+    end
   end
-  
+
   --- Get the y position of the cargo.
   -- @param #CARGO self
   -- @return #number
@@ -515,9 +512,9 @@ do -- CARGO
       return self.CargoCarrier:GetCoordinate().z
     else
       return self.CargoObject:GetCoordinate().z
-    end 
+    end
   end
-  
+
   --- Get the heading of the cargo.
   -- @param #CARGO self
   -- @return #number
@@ -526,22 +523,21 @@ do -- CARGO
       return self.CargoCarrier:GetHeading()
     else
       return self.CargoObject:GetHeading()
-    end 
+    end
   end
-  
-  
+
   --- Check if the cargo can be Slingloaded.
   -- @param #CARGO self
   function CARGO:CanSlingload()
     return false
   end
-  
+
   --- Check if the cargo can be Boarded.
   -- @param #CARGO self
   function CARGO:CanBoard()
     return true
   end
-  
+
   --- Check if the cargo can be Unboarded.
   -- @param #CARGO self
   function CARGO:CanUnboard()
@@ -553,14 +549,13 @@ do -- CARGO
   function CARGO:CanLoad()
     return true
   end
-  
+
   --- Check if the cargo can be Unloaded.
   -- @param #CARGO self
   function CARGO:CanUnload()
     return true
   end
 
-  
   --- Destroy the cargo.
   -- @param #CARGO self
   function CARGO:Destroy()
@@ -569,14 +564,14 @@ do -- CARGO
     end
     self:Destroyed()
   end
-  
+
   --- Get the name of the Cargo.
   -- @param #CARGO self
   -- @return #string The name of the Cargo.
   function CARGO:GetName() --R2.1
     return self.Name
   end
-  
+
   --- Get the current active object representing or being the Cargo.
   -- @param #CARGO self
   -- @return Wrapper.Positionable#POSITIONABLE The object representing or being the Cargo.
@@ -585,9 +580,9 @@ do -- CARGO
       return self.CargoCarrier
     else
       return self.CargoObject
-    end 
+    end
   end
-  
+
   --- Get the object name of the Cargo.
   -- @param #CARGO self
   -- @return #string The object name of the Cargo.
@@ -596,9 +591,9 @@ do -- CARGO
       return self.CargoCarrier:GetName()
     else
       return self.CargoObject:GetName()
-    end 
+    end
   end
-  
+
   --- Get the amount of Cargo.
   -- @param #CARGO self
   -- @return #number The amount of Cargo.
@@ -613,7 +608,6 @@ do -- CARGO
     return self.Type
   end
 
-    
   --- Get the transportation method of the Cargo.
   -- @param #CARGO self
   -- @return #string The transportation method of the Cargo.
@@ -621,7 +615,6 @@ do -- CARGO
     return self.TransportationMethod
   end
 
-    
   --- Get the coalition of the Cargo.
   -- @param #CARGO self
   -- @return Coalition
@@ -630,32 +623,30 @@ do -- CARGO
       return self.CargoCarrier:GetCoalition()
     else
       return self.CargoObject:GetCoalition()
-    end 
+    end
   end
 
-  
   --- Get the current coordinates of the Cargo.
   -- @param #CARGO self
   -- @return Core.Point#COORDINATE The coordinates of the Cargo.
   function CARGO:GetCoordinate()
     return self.CargoObject:GetCoordinate()
   end
-  
+
   --- Check if cargo is destroyed.
   -- @param #CARGO self
   -- @return #boolean true if destroyed
   function CARGO:IsDestroyed()
     return self:Is( "Destroyed" )
   end
-  
-  
+
   --- Check if cargo is loaded.
   -- @param #CARGO self
   -- @return #boolean true if loaded
   function CARGO:IsLoaded()
     return self:Is( "Loaded" )
   end
-  
+
   --- Check if cargo is loaded.
   -- @param #CARGO self
   -- @param Wrapper.Unit#UNIT Carrier
@@ -663,14 +654,14 @@ do -- CARGO
   function CARGO:IsLoadedInCarrier( Carrier )
     return self.CargoCarrier and self.CargoCarrier:GetName() == Carrier:GetName()
   end
-  
+
   --- Check if cargo is unloaded.
   -- @param #CARGO self
   -- @return #boolean true if unloaded
   function CARGO:IsUnLoaded()
     return self:Is( "UnLoaded" )
   end
-  
+
   --- Check if cargo is boarding.
   -- @param #CARGO self
   -- @return #boolean true if boarding
@@ -678,52 +669,47 @@ do -- CARGO
     return self:Is( "Boarding" )
   end
 
-  
   --- Check if cargo is unboarding.
   -- @param #CARGO self
   -- @return #boolean true if unboarding
   function CARGO:IsUnboarding()
     return self:Is( "UnBoarding" )
   end
-  
 
   --- Check if cargo is alive.
   -- @param #CARGO self
   -- @return #boolean true if unloaded
   function CARGO:IsAlive()
-  
+
     if self:IsLoaded() then
       return self.CargoCarrier:IsAlive()
     else
       return self.CargoObject:IsAlive()
-    end 
+    end
   end
-  
+
   --- Set the cargo as deployed.
   -- @param #CARGO self
   -- @param #boolean Deployed true if the cargo is to be deployed. false or nil otherwise.
   function CARGO:SetDeployed( Deployed )
     self.Deployed = Deployed
   end
-  
+
   --- Is the cargo deployed
   -- @param #CARGO self
   -- @return #boolean
   function CARGO:IsDeployed()
     return self.Deployed
   end
-  
-  
-  
-  
+
   --- Template method to spawn a new representation of the CARGO in the simulator.
   -- @param #CARGO self
   -- @return #CARGO
   function CARGO:Spawn( PointVec2 )
     self:F()
-  
+
   end
-  
+
   --- Signal a flare at the position of the CARGO.
   -- @param #CARGO self
   -- @param Utilities.Utils#FLARECOLOR FlareColor
@@ -732,31 +718,31 @@ do -- CARGO
       trigger.action.signalFlare( self.CargoObject:GetVec3(), FlareColor , 0 )
     end
   end
-  
+
   --- Signal a white flare at the position of the CARGO.
   -- @param #CARGO self
   function CARGO:FlareWhite()
     self:Flare( trigger.flareColor.White )
   end
-  
+
   --- Signal a yellow flare at the position of the CARGO.
   -- @param #CARGO self
   function CARGO:FlareYellow()
     self:Flare( trigger.flareColor.Yellow )
   end
-  
+
   --- Signal a green flare at the position of the CARGO.
   -- @param #CARGO self
   function CARGO:FlareGreen()
     self:Flare( trigger.flareColor.Green )
   end
-  
+
   --- Signal a red flare at the position of the CARGO.
   -- @param #CARGO self
   function CARGO:FlareRed()
     self:Flare( trigger.flareColor.Red )
   end
-  
+
   --- Smoke the CARGO.
   -- @param #CARGO self
   -- @param Utilities.Utils#SMOKECOLOR SmokeColor The color of the smoke.
@@ -770,38 +756,37 @@ do -- CARGO
       end
     end
   end
-  
+
   --- Smoke the CARGO Green.
   -- @param #CARGO self
   function CARGO:SmokeGreen()
     self:Smoke( trigger.smokeColor.Green, Range )
   end
-  
+
   --- Smoke the CARGO Red.
   -- @param #CARGO self
   function CARGO:SmokeRed()
     self:Smoke( trigger.smokeColor.Red, Range )
   end
-  
+
   --- Smoke the CARGO White.
   -- @param #CARGO self
   function CARGO:SmokeWhite()
     self:Smoke( trigger.smokeColor.White, Range )
   end
-  
+
   --- Smoke the CARGO Orange.
   -- @param #CARGO self
   function CARGO:SmokeOrange()
     self:Smoke( trigger.smokeColor.Orange, Range )
   end
-  
+
   --- Smoke the CARGO Blue.
   -- @param #CARGO self
   function CARGO:SmokeBlue()
     self:Smoke( trigger.smokeColor.Blue, Range )
   end
-  
-  
+
   --- Set the Load radius, which is the radius till when the Cargo can be loaded.
   -- @param #CARGO self
   -- @param #number LoadRadius The radius till Cargo can be loaded.
@@ -809,23 +794,21 @@ do -- CARGO
   function CARGO:SetLoadRadius( LoadRadius )
     self.LoadRadius = LoadRadius or 150
   end
-  
+
   --- Get the Load radius, which is the radius till when the Cargo can be loaded.
   -- @param #CARGO self
   -- @return #number The radius till Cargo can be loaded.
   function CARGO:GetLoadRadius()
     return self.LoadRadius
   end
-  
-  
-  
+
   --- Check if Cargo is in the LoadRadius for the Cargo to be Boarded or Loaded.
   -- @param #CARGO self
   -- @param Core.Point#COORDINATE Coordinate
   -- @return #boolean true if the CargoGroup is within the loading radius.
   function CARGO:IsInLoadRadius( Coordinate )
     self:F( { Coordinate, LoadRadius = self.LoadRadius } )
-  
+
     local Distance = 0
     if self:IsUnLoaded() then
       local CargoCoordinate = self.CargoObject:GetCoordinate()
@@ -835,10 +818,9 @@ do -- CARGO
         return true
       end
     end
-    
+
     return false
   end
-
 
   --- Check if the Cargo can report itself to be Boarded or Loaded.
   -- @param #CARGO self
@@ -846,7 +828,7 @@ do -- CARGO
   -- @return #boolean true if the Cargo can report itself.
   function CARGO:IsInReportRadius( Coordinate )
     self:F( { Coordinate } )
-  
+
     local Distance = 0
     if self:IsUnLoaded() then
       Distance = Coordinate:Get2DDistance( self.CargoObject:GetCoordinate() )
@@ -855,7 +837,7 @@ do -- CARGO
         return true
       end
     end
-    
+
     return false
   end
 
@@ -867,7 +849,7 @@ do -- CARGO
   -- @return #boolean
   function CARGO:IsNear( Coordinate, NearRadius )
     --self:F( { PointVec2 = PointVec2, NearRadius = NearRadius } )
-  
+
     if self.CargoObject:IsAlive() then
       --local Distance = PointVec2:Get2DDistance( self.CargoObject:GetPointVec2() )
       --self:F( { CargoObjectName = self.CargoObject:GetName() } )
@@ -875,26 +857,24 @@ do -- CARGO
       --self:F( { PointVec2 = PointVec2:GetVec2() } )
       local Distance = Coordinate:Get2DDistance( self.CargoObject:GetCoordinate() )
       --self:F( { Distance = Distance, NearRadius = NearRadius or "nil" }  )
-      
+
       if Distance <= NearRadius then
         --self:F( { PointVec2 = PointVec2, NearRadius = NearRadius, IsNear = true } )
         return true
       end
     end
-    
+
     --self:F( { PointVec2 = PointVec2, NearRadius = NearRadius, IsNear = false } )
     return false
   end
-  
-  
-  
-  --- Check if Cargo is the given @{Zone}.
+
+  --- Check if Cargo is the given @{Core.Zone}.
   -- @param #CARGO self
   -- @param Core.Zone#ZONE_BASE Zone
   -- @return #boolean **true** if cargo is in the Zone, **false** if cargo is not in the Zone.
   function CARGO:IsInZone( Zone )
     --self:F( { Zone } )
-  
+
     if self:IsLoaded() then
       return Zone:IsPointVec2InZone( self.CargoCarrier:GetPointVec2() )
     else
@@ -904,34 +884,33 @@ do -- CARGO
       else
         return false
       end
-    end  
-    
+    end
+
     return nil
-  
+
   end
-  
-  
+
   --- Get the current PointVec2 of the cargo.
   -- @param #CARGO self
   -- @return Core.Point#POINT_VEC2
   function CARGO:GetPointVec2()
     return self.CargoObject:GetPointVec2()
   end
-  
+
   --- Get the current Coordinate of the cargo.
   -- @param #CARGO self
   -- @return Core.Point#COORDINATE
   function CARGO:GetCoordinate()
     return self.CargoObject:GetCoordinate()
   end
-  
+
   --- Get the weight of the cargo.
   -- @param #CARGO self
   -- @return #number Weight The weight in kg.
   function CARGO:GetWeight()
     return self.Weight 
   end
-  
+
   --- Set the weight of the cargo.
   -- @param #CARGO self
   -- @param #number Weight The weight in kg.
@@ -940,14 +919,14 @@ do -- CARGO
     self.Weight = Weight
     return self
   end
-  
+
   --- Get the volume of the cargo.
   -- @param #CARGO self
   -- @return #number Volume The volume in kg.
   function CARGO:GetVolume()
     return self.Volume 
   end
-  
+
   --- Set the volume of the cargo.
   -- @param #CARGO self
   -- @param #number Volume The volume in kg.
@@ -956,18 +935,18 @@ do -- CARGO
     self.Volume = Volume
     return self
   end
-  
+
   --- Send a CC message to a @{Wrapper.Group}.
   -- @param #CARGO self
   -- @param #string Message
   -- @param Wrapper.Group#GROUP CarrierGroup The Carrier Group.
   -- @param #string Name (optional) The name of the Group used as a prefix for the message to the Group. If not provided, there will be nothing shown.
   function CARGO:MessageToGroup( Message, CarrierGroup, Name )
-  
+
     MESSAGE:New( Message, 20, "Cargo " .. self:GetName() ):ToGroup( CarrierGroup )
-  
+
   end
-  
+
   --- Report to a Carrier Group.
   -- @param #CARGO self
   -- @param #string Action The string describing the action for the cargo.
@@ -993,8 +972,7 @@ do -- CARGO
       end
     end
   end
-  
-  
+
   --- Report to a Carrier Group with a Flaring signal.
   -- @param #CARGO self
   -- @param Utils#UTILS.FlareColor FlareColor the color of the flare.
@@ -1003,8 +981,7 @@ do -- CARGO
 
     self.ReportFlareColor = FlareColor 
   end
-  
-  
+
   --- Report to a Carrier Group with a Smoking signal.
   -- @param #CARGO self
   -- @param Utils#UTILS.SmokeColor SmokeColor the color of the smoke.
@@ -1013,8 +990,7 @@ do -- CARGO
 
     self.ReportSmokeColor = SmokeColor 
   end
-  
-  
+
   --- Reset the reporting for a Carrier Group.
   -- @param #CARGO self
   -- @param #string Action The string describing the action for the cargo.
@@ -1024,7 +1000,7 @@ do -- CARGO
 
     self.Reported[CarrierGroup][Action] = nil
   end
-  
+
   --- Reset all the reporting for a Carrier Group.
   -- @param #CARGO self
   -- @param Wrapper.Group#GROUP CarrierGroup The Carrier Group to send the report to.
@@ -1033,7 +1009,7 @@ do -- CARGO
 
     self.Reported[CarrierGroup] = nil
   end
-  
+
   --- Respawn the cargo when destroyed
   -- @param #CARGO self
   -- @param #boolean RespawnDestroyed
@@ -1046,11 +1022,8 @@ do -- CARGO
     else
       self.onenterDestroyed = nil
     end
-      
-  end
-  
 
-  
+  end
 
 end -- CARGO
 
@@ -1075,7 +1048,7 @@ do -- CARGO_REPRESENTABLE
   -- @param #number NearRadius (optional) Radius in meters when the cargo is loaded into the carrier.
   -- @return #CARGO_REPRESENTABLE
   function CARGO_REPRESENTABLE:New( CargoObject, Type, Name, LoadRadius, NearRadius )
-  
+
     -- Inherit CARGO.
     local self = BASE:Inherit( self, CARGO:New( Type, Name, 0, LoadRadius, NearRadius ) ) -- #CARGO_REPRESENTABLE
     self:F( { Type, Name, LoadRadius, NearRadius } )
@@ -1083,10 +1056,10 @@ do -- CARGO_REPRESENTABLE
     -- Descriptors.
     local Desc=CargoObject:GetDesc()
     self:T({Desc=Desc})
-    
+
     -- Weight.
     local Weight = math.random( 80, 120 )
-    
+
     -- Adjust weight..
     if Desc then
       if Desc.typeName == "2B11 mortar" then
@@ -1097,8 +1070,8 @@ do -- CARGO_REPRESENTABLE
     end
 
     -- Set weight.
-    self:SetWeight( Weight )      
-    
+    self:SetWeight( Weight )
+
     return self
   end
 
@@ -1106,14 +1079,14 @@ do -- CARGO_REPRESENTABLE
   -- @param #CARGO_REPRESENTABLE self
   -- @return #CARGO_REPRESENTABLE
   function CARGO_REPRESENTABLE:Destroy()
-  
+
     -- Cargo objects are deleted from the _DATABASE and SET_CARGO objects.
     self:F( { CargoName = self:GetName() } )
     --_EVENTDISPATCHER:CreateEventDeleteCargo( self )
-  
+
     return self
   end
-  
+
   --- Route a cargo unit to a PointVec2.
   -- @param #CARGO_REPRESENTABLE self
   -- @param Core.Point#POINT_VEC2 ToPointVec2
@@ -1121,19 +1094,19 @@ do -- CARGO_REPRESENTABLE
   -- @return #CARGO_REPRESENTABLE
   function CARGO_REPRESENTABLE:RouteTo( ToPointVec2, Speed )
     self:F2( ToPointVec2 )
-  
+
     local Points = {}
-  
+
     local PointStartVec2 = self.CargoObject:GetPointVec2()
-  
+
     Points[#Points+1] = PointStartVec2:WaypointGround( Speed )
     Points[#Points+1] = ToPointVec2:WaypointGround( Speed )
-  
+
     local TaskRoute = self.CargoObject:TaskRoute( Points )
     self.CargoObject:SetTask( TaskRoute, 2 )
-    return self  
+    return self
   end
-  
+
   --- Send a message to a @{Wrapper.Group} through a communication channel near the cargo.
   -- @param #CARGO_REPRESENTABLE self
   -- @param #string Message
@@ -1157,20 +1130,19 @@ do -- CARGO_REPRESENTABLE
         end
       end
     end
-  
+
   end
 
-  
 end -- CARGO_REPRESENTABLE
 
 do -- CARGO_REPORTABLE
-  
+
     --- @type CARGO_REPORTABLE
     -- @extends #CARGO
     CARGO_REPORTABLE = {
       ClassName = "CARGO_REPORTABLE"
     }
-  
+
   --- CARGO_REPORTABLE Constructor.
   -- @param #CARGO_REPORTABLE self
   -- @param #string Type
@@ -1182,30 +1154,22 @@ do -- CARGO_REPORTABLE
   function CARGO_REPORTABLE:New( Type, Name, Weight, LoadRadius, NearRadius )
     local self = BASE:Inherit( self, CARGO:New( Type, Name, Weight, LoadRadius, NearRadius ) ) -- #CARGO_REPORTABLE
     self:F( { Type, Name, Weight, LoadRadius, NearRadius } )
-  
+
     return self
   end
-  
+
   --- Send a CC message to a @{Wrapper.Group}.
   -- @param #CARGO_REPORTABLE self
   -- @param #string Message
   -- @param Wrapper.Group#GROUP TaskGroup
   -- @param #string Name (optional) The name of the Group used as a prefix for the message to the Group. If not provided, there will be nothing shown.
   function CARGO_REPORTABLE:MessageToGroup( Message, TaskGroup, Name )
-  
+
     MESSAGE:New( Message, 20, "Cargo " .. self:GetName() .. " reporting" ):ToGroup( TaskGroup )
-  
+
   end
 
-
-  
 end
-
-
-
-
-
-
 
 do -- CARGO_PACKAGE
 
@@ -1280,10 +1244,10 @@ function CARGO_PACKAGE:IsNear( CargoCarrier )
   self:F()
 
   local CargoCarrierPoint = CargoCarrier:GetCoordinate()
-  
+
   local Distance = CargoCarrierPoint:Get2DDistance( self.CargoCarrier:GetCoordinate() )
   self:T( Distance )
-  
+
   if Distance <= self.NearRadius then
     return true
   else
@@ -1334,7 +1298,7 @@ function CARGO_PACKAGE:onafterUnBoard( From, Event, To, CargoCarrier, Speed, UnL
   if not self.CargoInAir then
 
     self:_Next( self.FsmP.UnLoad, UnLoadDistance, Angle )
-  
+
     local Points = {}
 
     local StartPointVec2 = CargoCarrier:GetPointVec2()
@@ -1389,7 +1353,7 @@ function CARGO_PACKAGE:onafterLoad( From, Event, To, CargoCarrier, Speed, LoadDi
   local CargoCarrierHeading = self.CargoCarrier:GetHeading() -- Get Heading of object in degrees.
   local CargoDeployHeading = ( ( CargoCarrierHeading + Angle ) >= 360 ) and ( CargoCarrierHeading + Angle - 360 ) or ( CargoCarrierHeading + Angle )
   local CargoDeployPointVec2 = StartPointVec2:Translate( LoadDistance, CargoDeployHeading )
-  
+
   local Points = {}
   Points[#Points+1] = StartPointVec2:WaypointGround( Speed )
   Points[#Points+1] = CargoDeployPointVec2:WaypointGround( Speed )
@@ -1410,12 +1374,12 @@ end
 -- @param #number Angle
 function CARGO_PACKAGE:onafterUnLoad( From, Event, To, CargoCarrier, Speed, Distance, Angle )
   self:F()
-  
+
   local StartPointVec2 = self.CargoCarrier:GetPointVec2()
   local CargoCarrierHeading = self.CargoCarrier:GetHeading() -- Get Heading of object in degrees.
   local CargoDeployHeading = ( ( CargoCarrierHeading + Angle ) >= 360 ) and ( CargoCarrierHeading + Angle - 360 ) or ( CargoCarrierHeading + Angle )
   local CargoDeployPointVec2 = StartPointVec2:Translate( Distance, CargoDeployHeading )
-  
+
   self.CargoCarrier = CargoCarrier
 
   local Points = {}
@@ -1426,6 +1390,5 @@ function CARGO_PACKAGE:onafterUnLoad( From, Event, To, CargoCarrier, Speed, Dist
   self.CargoCarrier:SetTask( TaskRoute, 1 )
 
 end
-
 
 end

--- a/Moose Development/Moose/Cargo/CargoGroup.lua
+++ b/Moose Development/Moose/Cargo/CargoGroup.lua
@@ -727,7 +727,7 @@ do -- CARGO_GROUP
     end
   end
   
-  --- Check if the first element of the CargoGroup is the given @{Zone}.
+  --- Check if the first element of the CargoGroup is the given @{Core.Zone}.
   -- @param #CARGO_GROUP self
   -- @param Core.Zone#ZONE_BASE Zone
   -- @return #boolean **true** if the first element of the CargoGroup is in the Zone

--- a/Moose Development/Moose/Core/Database.lua
+++ b/Moose Development/Moose/Core/Database.lua
@@ -246,7 +246,7 @@ end
 
 do -- Zones
 
-  --- Finds a @{Zone} based on the zone name.
+  --- Finds a @{Core.Zone} based on the zone name.
   -- @param #DATABASE self
   -- @param #string ZoneName The name of the zone.
   -- @return Core.Zone#ZONE_BASE The found ZONE.
@@ -256,7 +256,7 @@ do -- Zones
     return ZoneFound
   end
 
-  --- Adds a @{Zone} based on the zone name in the DATABASE.
+  --- Adds a @{Core.Zone} based on the zone name in the DATABASE.
   -- @param #DATABASE self
   -- @param #string ZoneName The name of the zone.
   -- @param Core.Zone#ZONE_BASE Zone The zone.
@@ -268,7 +268,7 @@ do -- Zones
   end
 
 
-  --- Deletes a @{Zone} from the DATABASE based on the zone name.
+  --- Deletes a @{Core.Zone} from the DATABASE based on the zone name.
   -- @param #DATABASE self
   -- @param #string ZoneName The name of the zone.
   function DATABASE:DeleteZone( ZoneName )
@@ -379,7 +379,7 @@ end -- zone
 
 do -- Zone_Goal
 
-  --- Finds a @{Zone} based on the zone name.
+  --- Finds a @{Core.Zone} based on the zone name.
   -- @param #DATABASE self
   -- @param #string ZoneName The name of the zone.
   -- @return Core.Zone#ZONE_BASE The found ZONE.
@@ -389,7 +389,7 @@ do -- Zone_Goal
     return ZoneFound
   end
 
-  --- Adds a @{Zone} based on the zone name in the DATABASE.
+  --- Adds a @{Core.Zone} based on the zone name in the DATABASE.
   -- @param #DATABASE self
   -- @param #string ZoneName The name of the zone.
   -- @param Core.Zone#ZONE_BASE Zone The zone.
@@ -401,7 +401,7 @@ do -- Zone_Goal
   end
 
 
-  --- Deletes a @{Zone} from the DATABASE based on the zone name.
+  --- Deletes a @{Core.Zone} from the DATABASE based on the zone name.
   -- @param #DATABASE self
   -- @param #string ZoneName The name of the zone.
   function DATABASE:DeleteZoneGoal( ZoneName )

--- a/Moose Development/Moose/Core/Set.lua
+++ b/Moose Development/Moose/Core/Set.lua
@@ -930,9 +930,9 @@ do -- SET_GROUP
   -- The following iterator methods are currently available within the SET_GROUP:
   --
   --   * @{#SET_GROUP.ForEachGroup}: Calls a function for each alive group it finds within the SET_GROUP.
-  --   * @{#SET_GROUP.ForEachGroupCompletelyInZone}: Iterate the SET_GROUP and call an iterator function for each **alive** GROUP presence completely in a @{Zone}, providing the GROUP and optional parameters to the called function.
-  --   * @{#SET_GROUP.ForEachGroupPartlyInZone}: Iterate the SET_GROUP and call an iterator function for each **alive** GROUP presence partly in a @{Zone}, providing the GROUP and optional parameters to the called function.
-  --   * @{#SET_GROUP.ForEachGroupNotInZone}: Iterate the SET_GROUP and call an iterator function for each **alive** GROUP presence not in a @{Zone}, providing the GROUP and optional parameters to the called function.
+  --   * @{#SET_GROUP.ForEachGroupCompletelyInZone}: Iterate the SET_GROUP and call an iterator function for each **alive** GROUP presence completely in a @{Core.Zone}, providing the GROUP and optional parameters to the called function.
+  --   * @{#SET_GROUP.ForEachGroupPartlyInZone}: Iterate the SET_GROUP and call an iterator function for each **alive** GROUP presence partly in a @{Core.Zone}, providing the GROUP and optional parameters to the called function.
+  --   * @{#SET_GROUP.ForEachGroupNotInZone}: Iterate the SET_GROUP and call an iterator function for each **alive** GROUP presence not in a @{Core.Zone}, providing the GROUP and optional parameters to the called function.
   --
   --
   -- ## SET_GROUP trigger events on the GROUP objects.
@@ -1486,7 +1486,7 @@ do -- SET_GROUP
   end
 
 
-  --- Iterate the SET_GROUP and call an iterator function for each **alive** GROUP presence completely in a @{Zone}, providing the GROUP and optional parameters to the called function.
+  --- Iterate the SET_GROUP and call an iterator function for each **alive** GROUP presence completely in a @{Core.Zone}, providing the GROUP and optional parameters to the called function.
   -- @param #SET_GROUP self
   -- @param Core.Zone#ZONE ZoneObject The Zone to be tested for.
   -- @param #function IteratorFunction The function that will be called when there is an alive GROUP in the SET_GROUP. The function needs to accept a GROUP parameter.
@@ -1508,7 +1508,7 @@ do -- SET_GROUP
     return self
   end
 
-  --- Iterate the SET_GROUP and call an iterator function for each **alive** GROUP presence partly in a @{Zone}, providing the GROUP and optional parameters to the called function.
+  --- Iterate the SET_GROUP and call an iterator function for each **alive** GROUP presence partly in a @{Core.Zone}, providing the GROUP and optional parameters to the called function.
   -- @param #SET_GROUP self
   -- @param Core.Zone#ZONE ZoneObject The Zone to be tested for.
   -- @param #function IteratorFunction The function that will be called when there is an alive GROUP in the SET_GROUP. The function needs to accept a GROUP parameter.
@@ -1530,7 +1530,7 @@ do -- SET_GROUP
     return self
   end
 
-  --- Iterate the SET_GROUP and call an iterator function for each **alive** GROUP presence not in a @{Zone}, providing the GROUP and optional parameters to the called function.
+  --- Iterate the SET_GROUP and call an iterator function for each **alive** GROUP presence not in a @{Core.Zone}, providing the GROUP and optional parameters to the called function.
   -- @param #SET_GROUP self
   -- @param Core.Zone#ZONE ZoneObject The Zone to be tested for.
   -- @param #function IteratorFunction The function that will be called when there is an alive GROUP in the SET_GROUP. The function needs to accept a GROUP parameter.
@@ -1624,7 +1624,7 @@ do -- SET_GROUP
     return false
   end
 
-  --- Iterate the SET_GROUP and return true if at least one @{#UNIT} of one @{GROUP} of the @{SET_GROUP} is in @{ZONE}
+  --- Iterate the SET_GROUP and return true if at least one @{#UNIT} of one @{GROUP} of the @{SET_GROUP} is in @{Core.Zone}
   -- @param #SET_GROUP self
   -- @param Core.Zone#ZONE ZoneObject The Zone to be tested for.
   -- @return #boolean true if at least one of the @{Wrapper.Group#GROUP} is partly or completely inside the @{Core.Zone#ZONE}, false otherwise.
@@ -1649,8 +1649,8 @@ do -- SET_GROUP
     return false
   end
 
-  --- Iterate the SET_GROUP and return true if at least one @{GROUP} of the @{SET_GROUP} is partly in @{ZONE}.
-  -- Will return false if a @{GROUP} is fully in the @{ZONE}
+  --- Iterate the SET_GROUP and return true if at least one @{GROUP} of the @{SET_GROUP} is partly in @{Core.Zone}.
+  -- Will return false if a @{GROUP} is fully in the @{Core.Zone}
   -- @param #SET_GROUP self
   -- @param Core.Zone#ZONE ZoneObject The Zone to be tested for.
   -- @return #boolean true if at least one of the @{Wrapper.Group#GROUP} is partly or completely inside the @{Core.Zone#ZONE}, false otherwise.
@@ -1683,7 +1683,7 @@ do -- SET_GROUP
     end
   end
 
-  --- Iterate the SET_GROUP and return true if no @{GROUP} of the @{SET_GROUP} is in @{ZONE}
+  --- Iterate the SET_GROUP and return true if no @{GROUP} of the @{SET_GROUP} is in @{Core.Zone}
   -- This could also be achieved with `not SET_GROUP:AnyPartlyInZone(Zone)`, but it's easier for the
   -- mission designer to add a dedicated method
   -- @param #SET_GROUP self
@@ -1952,14 +1952,14 @@ do -- SET_UNIT
   -- The following iterator methods are currently available within the SET_UNIT:
   --
   --   * @{#SET_UNIT.ForEachUnit}: Calls a function for each alive unit it finds within the SET_UNIT.
-  --   * @{#SET_UNIT.ForEachUnitInZone}: Iterate the SET_UNIT and call an iterator function for each **alive** UNIT object presence completely in a @{Zone}, providing the UNIT object and optional parameters to the called function.
-  --   * @{#SET_UNIT.ForEachUnitNotInZone}: Iterate the SET_UNIT and call an iterator function for each **alive** UNIT object presence not in a @{Zone}, providing the UNIT object and optional parameters to the called function.
+  --   * @{#SET_UNIT.ForEachUnitInZone}: Iterate the SET_UNIT and call an iterator function for each **alive** UNIT object presence completely in a @{Core.Zone}, providing the UNIT object and optional parameters to the called function.
+  --   * @{#SET_UNIT.ForEachUnitNotInZone}: Iterate the SET_UNIT and call an iterator function for each **alive** UNIT object presence not in a @{Core.Zone}, providing the UNIT object and optional parameters to the called function.
   --
   -- Planned iterators methods in development are (so these are not yet available):
   --
   --   * @{#SET_UNIT.ForEachUnitInUnit}: Calls a function for each unit contained within the SET_UNIT.
-  --   * @{#SET_UNIT.ForEachUnitCompletelyInZone}: Iterate and call an iterator function for each **alive** UNIT presence completely in a @{Zone}, providing the UNIT and optional parameters to the called function.
-  --   * @{#SET_UNIT.ForEachUnitNotInZone}: Iterate and call an iterator function for each **alive** UNIT presence not in a @{Zone}, providing the UNIT and optional parameters to the called function.
+  --   * @{#SET_UNIT.ForEachUnitCompletelyInZone}: Iterate and call an iterator function for each **alive** UNIT presence completely in a @{Core.Zone}, providing the UNIT and optional parameters to the called function.
+  --   * @{#SET_UNIT.ForEachUnitNotInZone}: Iterate and call an iterator function for each **alive** UNIT presence not in a @{Core.Zone}, providing the UNIT and optional parameters to the called function.
   --
   -- ## 5) SET_UNIT atomic methods
   --
@@ -2501,7 +2501,7 @@ do -- SET_UNIT
     return self
   end
 
-  --- Iterate the SET_UNIT and call an iterator function for each **alive** UNIT presence completely in a @{Zone}, providing the UNIT and optional parameters to the called function.
+  --- Iterate the SET_UNIT and call an iterator function for each **alive** UNIT presence completely in a @{Core.Zone}, providing the UNIT and optional parameters to the called function.
   -- @param #SET_UNIT self
   -- @param Core.Zone#ZONE ZoneObject The Zone to be tested for.
   -- @param #function IteratorFunction The function that will be called when there is an alive UNIT in the SET_UNIT. The function needs to accept a UNIT parameter.
@@ -2523,7 +2523,7 @@ do -- SET_UNIT
     return self
   end
 
-  --- Iterate the SET_UNIT and call an iterator function for each **alive** UNIT presence not in a @{Zone}, providing the UNIT and optional parameters to the called function.
+  --- Iterate the SET_UNIT and call an iterator function for each **alive** UNIT presence not in a @{Core.Zone}, providing the UNIT and optional parameters to the called function.
   -- @param #SET_UNIT self
   -- @param Core.Zone#ZONE ZoneObject The Zone to be tested for.
   -- @param #function IteratorFunction The function that will be called when there is an alive UNIT in the SET_UNIT. The function needs to accept a UNIT parameter.
@@ -3075,9 +3075,9 @@ do -- SET_STATIC
   -- The following iterator methods are currently available within the SET_STATIC:
   --
   --   * @{#SET_STATIC.ForEachStatic}: Calls a function for each alive unit it finds within the SET_STATIC.
-  --   * @{#SET_STATIC.ForEachStaticCompletelyInZone}: Iterate the SET_STATIC and call an iterator function for each **alive** STATIC presence completely in a @{Zone}, providing the STATIC and optional parameters to the called function.
-  --   * @{#SET_STATIC.ForEachStaticInZone}: Iterate the SET_STATIC and call an iterator function for each **alive** STATIC presence completely in a @{Zone}, providing the STATIC and optional parameters to the called function.
-  --   * @{#SET_STATIC.ForEachStaticNotInZone}: Iterate the SET_STATIC and call an iterator function for each **alive** STATIC presence not in a @{Zone}, providing the STATIC and optional parameters to the called function.
+  --   * @{#SET_STATIC.ForEachStaticCompletelyInZone}: Iterate the SET_STATIC and call an iterator function for each **alive** STATIC presence completely in a @{Core.Zone}, providing the STATIC and optional parameters to the called function.
+  --   * @{#SET_STATIC.ForEachStaticInZone}: Iterate the SET_STATIC and call an iterator function for each **alive** STATIC presence completely in a @{Core.Zone}, providing the STATIC and optional parameters to the called function.
+  --   * @{#SET_STATIC.ForEachStaticNotInZone}: Iterate the SET_STATIC and call an iterator function for each **alive** STATIC presence not in a @{Core.Zone}, providing the STATIC and optional parameters to the called function.
   --
   -- ## SET_STATIC atomic methods
   --
@@ -3441,7 +3441,7 @@ do -- SET_STATIC
     return self
   end
 
-  --- Iterate the SET_STATIC and call an iterator function for each **alive** STATIC presence completely in a @{Zone}, providing the STATIC and optional parameters to the called function.
+  --- Iterate the SET_STATIC and call an iterator function for each **alive** STATIC presence completely in a @{Core.Zone}, providing the STATIC and optional parameters to the called function.
   -- @param #SET_STATIC self
   -- @param Core.Zone#ZONE ZoneObject The Zone to be tested for.
   -- @param #function IteratorFunction The function that will be called when there is an alive STATIC in the SET_STATIC. The function needs to accept a STATIC parameter.
@@ -3463,7 +3463,7 @@ do -- SET_STATIC
     return self
   end
 
-  --- Iterate the SET_STATIC and call an iterator function for each **alive** STATIC presence not in a @{Zone}, providing the STATIC and optional parameters to the called function.
+  --- Iterate the SET_STATIC and call an iterator function for each **alive** STATIC presence not in a @{Core.Zone}, providing the STATIC and optional parameters to the called function.
   -- @param #SET_STATIC self
   -- @param Core.Zone#ZONE ZoneObject The Zone to be tested for.
   -- @param #function IteratorFunction The function that will be called when there is an alive STATIC in the SET_STATIC. The function needs to accept a STATIC parameter.
@@ -4073,7 +4073,7 @@ do -- SET_CLIENT
     return self
   end
 
-  --- Iterate the SET_CLIENT and call an iterator function for each **alive** CLIENT presence completely in a @{Zone}, providing the CLIENT and optional parameters to the called function.
+  --- Iterate the SET_CLIENT and call an iterator function for each **alive** CLIENT presence completely in a @{Core.Zone}, providing the CLIENT and optional parameters to the called function.
   -- @param #SET_CLIENT self
   -- @param Core.Zone#ZONE ZoneObject The Zone to be tested for.
   -- @param #function IteratorFunction The function that will be called when there is an alive CLIENT in the SET_CLIENT. The function needs to accept a CLIENT parameter.
@@ -4095,7 +4095,7 @@ do -- SET_CLIENT
     return self
   end
 
-  --- Iterate the SET_CLIENT and call an iterator function for each **alive** CLIENT presence not in a @{Zone}, providing the CLIENT and optional parameters to the called function.
+  --- Iterate the SET_CLIENT and call an iterator function for each **alive** CLIENT presence not in a @{Core.Zone}, providing the CLIENT and optional parameters to the called function.
   -- @param #SET_CLIENT self
   -- @param Core.Zone#ZONE ZoneObject The Zone to be tested for.
   -- @param #function IteratorFunction The function that will be called when there is an alive CLIENT in the SET_CLIENT. The function needs to accept a CLIENT parameter.
@@ -4545,7 +4545,7 @@ do -- SET_PLAYER
     return self
   end
 
-  --- Iterate the SET_PLAYER and call an iterator function for each **alive** CLIENT presence completely in a @{Zone}, providing the CLIENT and optional parameters to the called function.
+  --- Iterate the SET_PLAYER and call an iterator function for each **alive** CLIENT presence completely in a @{Core.Zone}, providing the CLIENT and optional parameters to the called function.
   -- @param #SET_PLAYER self
   -- @param Core.Zone#ZONE ZoneObject The Zone to be tested for.
   -- @param #function IteratorFunction The function that will be called when there is an alive CLIENT in the SET_PLAYER. The function needs to accept a CLIENT parameter.
@@ -4567,7 +4567,7 @@ do -- SET_PLAYER
     return self
   end
 
-  --- Iterate the SET_PLAYER and call an iterator function for each **alive** CLIENT presence not in a @{Zone}, providing the CLIENT and optional parameters to the called function.
+  --- Iterate the SET_PLAYER and call an iterator function for each **alive** CLIENT presence not in a @{Core.Zone}, providing the CLIENT and optional parameters to the called function.
   -- @param #SET_PLAYER self
   -- @param Core.Zone#ZONE ZoneObject The Zone to be tested for.
   -- @param #function IteratorFunction The function that will be called when there is an alive CLIENT in the SET_PLAYER. The function needs to accept a CLIENT parameter.

--- a/Moose Development/Moose/Core/Spawn.lua
+++ b/Moose Development/Moose/Core/Spawn.lua
@@ -167,7 +167,7 @@
 --
 --   * @{#SPAWN.InitRandomizePosition}(): Randomizes the position of @{Wrapper.Group}s that are spawned within a **radius band**, given an Outer and Inner radius, from the point that the spawn happens.
 --   * @{#SPAWN.InitRandomizeUnits}(): Randomizes the @{Wrapper.Unit}s in the @{Wrapper.Group} that is spawned within a **radius band**, given an Outer and Inner radius.
---   * @{#SPAWN.InitRandomizeZones}(): Randomizes the spawning between a predefined list of @{Zone}s that are declared using this function. Each zone can be given a probability factor.
+--   * @{#SPAWN.InitRandomizeZones}(): Randomizes the spawning between a predefined list of @{Core.Zone}s that are declared using this function. Each zone can be given a probability factor.
 --
 -- ### Enable / Disable AI when spawning a new @{Wrapper.Group}
 --
@@ -202,7 +202,7 @@
 --   * @{#SPAWN.SpawnFromVec2}(): Spawn a new group from a Vec2 coordinate. (The group will be spawned at land height ).
 --   * @{#SPAWN.SpawnFromStatic}(): Spawn a new group from a structure, taking the position of a @{Wrapper.Static}.
 --   * @{#SPAWN.SpawnFromUnit}(): Spawn a new group taking the position of a @{Wrapper.Unit}.
---   * @{#SPAWN.SpawnInZone}(): Spawn a new group in a @{Zone}.
+--   * @{#SPAWN.SpawnInZone}(): Spawn a new group in a @{Core.Zone}.
 --   * @{#SPAWN.SpawnAtAirbase}(): Spawn a new group at an @{Wrapper.Airbase}, which can be an airdrome, ship or helipad.
 --
 -- Note that @{#SPAWN.Spawn} and @{#SPAWN.ReSpawn} return a @{Wrapper.Group#GROUP.New} object, that contains a reference to the DCSGroup object.
@@ -906,7 +906,7 @@ end
 
 --- This method provides the functionality to randomize the spawning of the Groups at a given list of zones of different types.
 -- @param #SPAWN self
--- @param #table SpawnZoneTable A table with @{Zone} objects. If this table is given, then each spawn will be executed within the given list of @{Zone}s objects.
+-- @param #table SpawnZoneTable A table with @{Core.Zone} objects. If this table is given, then each spawn will be executed within the given list of @{Core.Zone}s objects.
 -- @return #SPAWN
 -- @usage
 --
@@ -2615,8 +2615,8 @@ function SPAWN:SpawnFromStatic( HostStatic, MinHeight, MaxHeight, SpawnIndex )
   return nil
 end
 
---- Will spawn a Group within a given @{Zone}.
--- The @{Zone} can be of any type derived from @{Core.Zone#ZONE_BASE}.
+--- Will spawn a Group within a given @{Core.Zone}.
+-- The @{Core.Zone} can be of any type derived from @{Core.Zone#ZONE_BASE}.
 -- Once the @{Wrapper.Group} is spawned within the zone, the @{Wrapper.Group} will continue on its route.
 -- The **first waypoint** (where the group is spawned) is replaced with the zone location coordinates.
 -- @param #SPAWN self
@@ -3108,7 +3108,7 @@ function SPAWN:_RandomizeTemplate( SpawnIndex )
   return self
 end
 
---- Private method that randomizes the @{Zone}s where the Group will be spawned.
+--- Private method that randomizes the @{Core.Zone}s where the Group will be spawned.
 -- @param #SPAWN self
 -- @param #number SpawnIndex
 -- @return #SPAWN self

--- a/Moose Development/Moose/Core/SpawnStatic.lua
+++ b/Moose Development/Moose/Core/SpawnStatic.lua
@@ -106,7 +106,7 @@
 --   * @{#SPAWNSTATIC.Spawn}(Heading, NewName) spawns the static with the set parameters. Optionally, heading and name can be given. The name **must be unique**!
 --   * @{#SPAWNSTATIC.SpawnFromCoordinate}(Coordinate, Heading, NewName) spawn the static at the given coordinate. Optionally, heading and name can be given. The name **must be unique**!
 --   * @{#SPAWNSTATIC.SpawnFromPointVec2}(PointVec2, Heading, NewName) spawns the static at a POINT_VEC2 coordinate. Optionally, heading and name can be given. The name **must be unique**!
---   * @{#SPAWNSTATIC.SpawnFromZone}(Zone, Heading, NewName) spawns the static at the center of a @{Zone}. Optionally, heading and name can be given. The name **must be unique**!
+--   * @{#SPAWNSTATIC.SpawnFromZone}(Zone, Heading, NewName) spawns the static at the center of a @{Core.Zone}. Optionally, heading and name can be given. The name **must be unique**!
 --  
 -- @field #SPAWNSTATIC SPAWNSTATIC
 -- 
@@ -375,7 +375,7 @@ function SPAWNSTATIC:SpawnFromCoordinate(Coordinate, Heading, NewName)
 end
 
 
---- Creates a new @{Wrapper.Static} from a @{Zone}.
+--- Creates a new @{Wrapper.Static} from a @{Core.Zone}.
 -- @param #SPAWNSTATIC self
 -- @param Core.Zone#ZONE_BASE Zone The Zone where to spawn the static.
 -- @param #number Heading (Optional)The heading of the static in degrees. Default is the heading of the template.

--- a/Moose Development/Moose/Core/Zone.lua
+++ b/Moose Development/Moose/Core/Zone.lua
@@ -53,7 +53,6 @@
 -- @module Core.Zone
 -- @image Core_Zones.JPG
 
-
 --- @type ZONE_BASE
 -- @field #string ZoneName Name of the zone.
 -- @field #number ZoneProbability A value between 0 and 1. 0 = 0% and 1 = 100% probability.
@@ -75,7 +74,7 @@
 --   * @{#ZONE_BASE.SetName}(): Sets the name of the zone.
 --
 --
--- ## Each zone implements two polymorphic functions defined in @{Core.Zone#ZONE_BASE}:
+-- ## Each zone implements two polymorphic functions defined in @{#ZONE_BASE}:
 --
 --   * @{#ZONE_BASE.IsVec2InZone}(): Returns if a 2D vector is within the zone.
 --   * @{#ZONE_BASE.IsVec3InZone}(): Returns if a 3D vector is within the zone.
@@ -121,9 +120,8 @@ ZONE_BASE = {
   Color={},
   ZoneID=nil,
   Properties={},
-  Sureface=nil,
+  Surface=nil,
 }
-
 
 --- The ZONE_BASE.BoundingSquare
 -- @type ZONE_BASE.BoundingSquare
@@ -131,7 +129,6 @@ ZONE_BASE = {
 -- @field DCS#Distance y1 The lower y coordinate (left down)
 -- @field DCS#Distance x2 The higher x coordinate (right up)
 -- @field DCS#Distance y2 The higher y coordinate (right up)
-
 
 --- ZONE_BASE constructor
 -- @param #ZONE_BASE self
@@ -142,13 +139,11 @@ function ZONE_BASE:New( ZoneName )
   self:F( ZoneName )
 
   self.ZoneName = ZoneName
-  
+
   --_DATABASE:AddZone(ZoneName,self)
-  
+
   return self
 end
-
-
 
 --- Returns the name of the zone.
 -- @param #ZONE_BASE self
@@ -158,7 +153,6 @@ function ZONE_BASE:GetName()
 
   return self.ZoneName
 end
-
 
 --- Sets the name of the zone.
 -- @param #ZONE_BASE self
@@ -217,7 +211,6 @@ function ZONE_BASE:IsPointVec3InZone( PointVec3 )
   return InZone
 end
 
-
 --- Returns the @{DCS#Vec2} coordinate of the zone.
 -- @param #ZONE_BASE self
 -- @return #nil.
@@ -240,7 +233,6 @@ function ZONE_BASE:GetPointVec2()
 
   return PointVec2
 end
-
 
 --- Returns the @{DCS#Vec3} of the zone.
 -- @param #ZONE_BASE self
@@ -365,7 +357,6 @@ function ZONE_BASE:BoundZone()
   self:F2()
 end
 
-
 --- Set draw coalition of zone.
 -- @param #ZONE_BASE self
 -- @param #number Coalition Coalition. Default -1.
@@ -377,7 +368,7 @@ end
 
 --- Get draw coalition of zone.
 -- @param #ZONE_BASE self
--- @return #number Draw coaliton.
+-- @return #number Draw coalition.
 function ZONE_BASE:GetDrawCoalition()
   return self.drawCoalition or -1
 end
@@ -385,7 +376,7 @@ end
 --- Set color of zone.
 -- @param #ZONE_BASE self
 -- @param #table RGBcolor RGB color table. Default `{1, 0, 0}`.
--- @param #number Alpha Transparacy between 0 and 1. Default 0.15.
+-- @param #number Alpha Transparency between 0 and 1. Default 0.15.
 -- @return #ZONE_BASE self
 function ZONE_BASE:SetColor(RGBcolor, Alpha)
 
@@ -420,7 +411,7 @@ function ZONE_BASE:GetColorRGB()
   return rgb
 end
 
---- Get transperency Alpha value of zone.
+--- Get transparency Alpha value of zone.
 -- @param #ZONE_BASE self
 -- @return #number Alpha value.
 function ZONE_BASE:GetColorAlpha()
@@ -467,7 +458,7 @@ function ZONE_BASE:GetFillColorRGB()
   return rgb
 end
 
---- Get transperency Alpha fill value of zone.
+--- Get transparency Alpha fill value of zone.
 -- @param #ZONE_BASE self
 -- @return #number Alpha value.
 function ZONE_BASE:GetFillColorAlpha()
@@ -592,7 +583,7 @@ end
 -- @extends #ZONE_BASE
 
 --- The ZONE_RADIUS class defined by a zone name, a location and a radius.
--- This class implements the inherited functions from Core.Zone#ZONE_BASE taking into account the own zone format and properties.
+-- This class implements the inherited functions from @{#ZONE_BASE} taking into account the own zone format and properties.
 --
 -- ## ZONE_RADIUS constructor
 --
@@ -631,7 +622,7 @@ ZONE_RADIUS = {
 -- @param #string ZoneName Name of the zone.
 -- @param DCS#Vec2 Vec2 The location of the zone.
 -- @param DCS#Distance Radius The radius of the zone.
--- @param DCS#Boolean DoNotRegisterZone Determins if the Zone should not be registered in the _Database Table. Default=false
+-- @param DCS#Boolean DoNotRegisterZone Determines if the Zone should not be registered in the _Database Table. Default=false
 -- @return #ZONE_RADIUS self
 function ZONE_RADIUS:New( ZoneName, Vec2, Radius, DoNotRegisterZone )
 
@@ -755,7 +746,6 @@ function ZONE_RADIUS:BoundZone( Points, CountryID, UnBound )
   local Angle
   local RadialBase = math.pi*2
 
-  --
   for Angle = 0, 360, (360 / Points ) do
     local Radial = Angle * RadialBase / 360
     Point.x = Vec2.x + math.cos( Radial ) * self:GetRadius()
@@ -784,7 +774,6 @@ function ZONE_RADIUS:BoundZone( Points, CountryID, UnBound )
 
   return self
 end
-
 
 --- Smokes the zone boundaries in a color.
 -- @param #ZONE_RADIUS self
@@ -816,7 +805,6 @@ function ZONE_RADIUS:SmokeZone( SmokeColor, Points, AddHeight, AngleOffset )
 
   return self
 end
-
 
 --- Flares the zone boundaries in a color.
 -- @param #ZONE_RADIUS self
@@ -914,7 +902,6 @@ function ZONE_RADIUS:GetVec3( Height )
   return Vec3
 end
 
-
 --- Scan the zone for the presence of units of the given ObjectCategories.
 -- Note that **only after** a zone has been scanned, the zone can be evaluated by:
 --
@@ -955,7 +942,7 @@ function ZONE_RADIUS:Scan( ObjectCategories, UnitCategories )
     if ZoneObject then
 
       local ObjectCategory = ZoneObject:getCategory()
-      
+
       --local name=ZoneObject:getName()
       --env.info(string.format("Zone object %s", tostring(name)))
       --self:E(ZoneObject)
@@ -1022,7 +1009,6 @@ function ZONE_RADIUS:GetScannedUnits()
   return self.ScanData.Units
 end
 
-
 --- Get a set of scanned units.
 -- @param #ZONE_RADIUS self
 -- @return Core.Set#SET_UNIT Set of units and statics inside the zone.
@@ -1076,7 +1062,6 @@ function ZONE_RADIUS:GetScannedSetGroup()
   return self.ScanSetGroup
 end
 
-
 --- Count the number of different coalitions inside the zone.
 -- @param #ZONE_RADIUS self
 -- @return #number Counted coalitions.
@@ -1129,14 +1114,12 @@ function ZONE_RADIUS:GetScannedCoalition( Coalition )
   end
 end
 
-
 --- Get scanned scenery type
 -- @param #ZONE_RADIUS self
 -- @return #table Table of DCS scenery type objects.
 function ZONE_RADIUS:GetScannedSceneryType( SceneryType )
   return self.ScanData.Scenery[SceneryType]
 end
-
 
 --- Get scanned scenery table
 -- @param #ZONE_RADIUS self
@@ -1165,7 +1148,7 @@ function ZONE_RADIUS:GetScannedSetScenery()
 end
 
 --- Is All in Zone of Coalition?
--- Check if only the specifed coalition is inside the zone and noone else.
+-- Check if only the specified coalition is inside the zone and no one else.
 -- @param #ZONE_RADIUS self
 -- @param #number Coalition Coalition ID of the coalition which is checked to be the only one in the zone.
 -- @return #boolean True, if **only** that coalition is inside the zone and no one else.
@@ -1177,7 +1160,6 @@ function ZONE_RADIUS:IsAllInZoneOfCoalition( Coalition )
   --self:E( { Coalitions = self.Coalitions, Count = self:CountScannedCoalitions() } )
   return self:CountScannedCoalitions() == 1 and self:GetScannedCoalition( Coalition ) == true
 end
-
 
 --- Is All in Zone of Other Coalition?
 -- Check if only one coalition is inside the zone and the specified coalition is not the one.
@@ -1195,13 +1177,12 @@ function ZONE_RADIUS:IsAllInZoneOfOtherCoalition( Coalition )
   return self:CountScannedCoalitions() == 1 and self:GetScannedCoalition( Coalition ) == nil
 end
 
-
 --- Is Some in Zone of Coalition?
--- Check if more than one coaltion is inside the zone and the specifed coalition is one of them.
+-- Check if more than one coalition is inside the zone and the specified coalition is one of them.
 -- You first need to use the @{#ZONE_RADIUS.Scan} method to scan the zone before it can be evaluated!
 -- Note that once a zone has been scanned, multiple evaluations can be done on the scan result set.
 -- @param #ZONE_RADIUS self
--- @param #number Coalition ID of the coaliton which is checked to be inside the zone.
+-- @param #number Coalition ID of the coalition which is checked to be inside the zone.
 -- @return #boolean True if more than one coalition is inside the zone and the specified coalition is one of them.
 -- @usage
 --    self.Zone:Scan()
@@ -1210,7 +1191,6 @@ function ZONE_RADIUS:IsSomeInZoneOfCoalition( Coalition )
 
   return self:CountScannedCoalitions() > 1 and self:GetScannedCoalition( Coalition ) == true
 end
-
 
 --- Is None in Zone of Coalition?
 -- You first need to use the @{#ZONE_RADIUS.Scan} method to scan the zone before it can be evaluated!
@@ -1226,7 +1206,6 @@ function ZONE_RADIUS:IsNoneInZoneOfCoalition( Coalition )
   return self:GetScannedCoalition( Coalition ) == nil
 end
 
-
 --- Is None in Zone?
 -- You first need to use the @{#ZONE_RADIUS.Scan} method to scan the zone before it can be evaluated!
 -- Note that once a zone has been scanned, multiple evaluations can be done on the scan result set.
@@ -1239,9 +1218,6 @@ function ZONE_RADIUS:IsNoneInZone()
 
   return self:CountScannedCoalitions() == 0
 end
-
-
-
 
 --- Searches the zone
 -- @param #ZONE_RADIUS self
@@ -1282,9 +1258,9 @@ end
 -- @return #boolean true if the location is within the zone.
 function ZONE_RADIUS:IsVec2InZone( Vec2 )
   self:F2( Vec2 )
-  
+
   if not Vec2 then return false end 
-  
+
   local ZoneVec2 = self:GetVec2()
 
   if ZoneVec2 then
@@ -1352,7 +1328,7 @@ function ZONE_RADIUS:GetRandomVec2(inner, outer, surfacetypes)
         --env.info(string.format("Got random coordinate with surface type %d after N=%d/%d iterations", land.getSurfaceType(point), N, Nmax))
       else
         point=_getpoint()
-        N=N+1      
+        N=N+1
       end
     end
   end
@@ -1427,27 +1403,26 @@ end
 -- @param #ZONE_RADIUS self
 -- @param #number inner (Optional) Minimal distance from the center of the zone in meters. Default is 0m.
 -- @param #number outer (Optional) Maximal distance from the outer edge of the zone in meters. Default is the radius of the zone.
--- @param #number distance (Optional) Minumum distance from any building coordinate. Defaults to 100m.
+-- @param #number distance (Optional) Minimum distance from any building coordinate. Defaults to 100m.
 -- @param #boolean markbuildings (Optional) Place markers on found buildings (if any).
 -- @param #boolean markfinal (Optional) Place marker on the final coordinate (if any).
 -- @return Core.Point#COORDINATE The random coordinate or `nil` if cannot be found in 1000 iterations.
 function ZONE_RADIUS:GetRandomCoordinateWithoutBuildings(inner,outer,distance,markbuildings,markfinal)
-  
+
   local dist = distance or 100
-  
+
   local objects = {}
-  
+
   if self.ScanData and self.ScanData.Scenery then
     objects = self:GetScannedScenery()
   else
     self:Scan({Object.Category.SCENERY})
     objects = self:GetScannedScenery()
   end
-  
+
   local T0 = timer.getTime()
   local T1 = timer.getTime()
-  
-  
+
   local buildings = {}
   if self.ScanData and self.ScanData.BuildingCoordinates then
     buildings = self.ScanData.BuildingCoordinates
@@ -1467,12 +1442,12 @@ function ZONE_RADIUS:GetRandomCoordinateWithoutBuildings(inner,outer,distance,ma
     end
     self.ScanData.BuildingCoordinates = buildings
   end
-  
+
   -- max 1000 tries
   local rcoord = nil  
   local found = false
   local iterations = 0
-  
+
   for i=1,1000 do
     iterations = iterations + 1
     rcoord = self:GetRandomCoordinate(inner,outer)
@@ -1593,7 +1568,7 @@ end
 -- @extends Core.Zone#ZONE_RADIUS
 
 
---- # ZONE_UNIT class, extends @{Zone#ZONE_RADIUS}
+--- # ZONE_UNIT class, extends @{#ZONE_RADIUS}
 --
 -- The ZONE_UNIT class defined by a zone attached to a @{Wrapper.Unit#UNIT} with a radius and optional offsets.
 -- This class implements the inherited functions from @{#ZONE_RADIUS} taking into account the own zone format and properties.
@@ -1733,7 +1708,7 @@ end
 
 
 --- The ZONE_GROUP class defines by a zone around a @{Wrapper.Group#GROUP} with a radius. The current leader of the group defines the center of the zone.
--- This class implements the inherited functions from @{Core.Zone#ZONE_RADIUS} taking into account the own zone format and properties.
+-- This class implements the inherited functions from @{#ZONE_RADIUS} taking into account the own zone format and properties.
 --
 -- @field #ZONE_GROUP
 ZONE_GROUP = {
@@ -1820,7 +1795,7 @@ end
 
 
 --- The ZONE_POLYGON_BASE class defined by a sequence of @{Wrapper.Group#GROUP} waypoints within the Mission Editor, forming a polygon.
--- This class implements the inherited functions from @{Core.Zone#ZONE_RADIUS} taking into account the own zone format and properties.
+-- This class implements the inherited functions from @{#ZONE_RADIUS} taking into account the own zone format and properties.
 -- This class is an abstract BASE class for derived classes, and is not meant to be instantiated.
 --
 -- ## Zone point randomization
@@ -2052,7 +2027,6 @@ function ZONE_POLYGON_BASE:BoundZone( UnBound )
   return self
 end
 
-
 --- Draw the zone on the F10 map.  **NOTE** Currently, only polygons **up to ten points** are supported!
 -- @param #ZONE_POLYGON_BASE self
 -- @param #number Coalition Coalition: All=-1, Neutral=0, Red=1, Blue=2. Default -1=All.
@@ -2068,43 +2042,43 @@ function ZONE_POLYGON_BASE:DrawZone(Coalition, Color, Alpha, FillColor, FillAlph
   if self._.Polygon and #self._.Polygon>=3 then
 
     local coordinate=COORDINATE:NewFromVec2(self._.Polygon[1])
-    
+
     Coalition=Coalition or self:GetDrawCoalition()
-    
+
     -- Set draw coalition.
-    self:SetDrawCoalition(Coalition)  
-  
+    self:SetDrawCoalition(Coalition)
+
     Color=Color or self:GetColorRGB()
     Alpha=Alpha or 1
-    
+
     -- Set color.
     self:SetColor(Color, Alpha)
-    
+
     FillColor=FillColor or self:GetFillColorRGB()
     if not FillColor then UTILS.DeepCopy(Color) end
     FillAlpha=FillAlpha or self:GetFillColorAlpha()
     if not FillAlpha then FillAlpha=0.15 end
-    
+
     -- Set fill color.
     self:SetFillColor(FillColor, FillAlpha)
-  
+
     if #self._.Polygon==4 then
-  
+
       local Coord2=COORDINATE:NewFromVec2(self._.Polygon[2])
       local Coord3=COORDINATE:NewFromVec2(self._.Polygon[3])
       local Coord4=COORDINATE:NewFromVec2(self._.Polygon[4])
-  
+
       self.DrawID=coordinate:QuadToAll(Coord2, Coord3, Coord4, Coalition, Color, Alpha, FillColor, FillAlpha, LineType, ReadOnly)
-  
+
     else
-  
+
       local Coordinates=self:GetVerticiesCoordinates()
       table.remove(Coordinates, 1)
-  
+
       self.DrawID=coordinate:MarkupToAllFreeForm(Coordinates, Coalition, Color, Alpha, FillColor, FillAlpha, LineType, ReadOnly)
-  
+
     end
-    
+
   end
 
   return self
@@ -2141,7 +2115,6 @@ function ZONE_POLYGON_BASE:SmokeZone( SmokeColor, Segments )
   return self
 end
 
-
 --- Flare the zone boundaries in a color.
 -- @param #ZONE_POLYGON_BASE self
 -- @param Utilities.Utils#FLARECOLOR FlareColor The flare color.
@@ -2176,9 +2149,6 @@ function ZONE_POLYGON_BASE:FlareZone( FlareColor, Segments, Azimuth, AddHeight )
 
   return self
 end
-
-
-
 
 --- Returns if a location is within the zone.
 -- Source learned and taken from: https://www.ecse.rpi.edu/Homepages/wrf/Research/Short_Notes/pnpoly.html
@@ -2361,7 +2331,7 @@ end
 
 
 --- The ZONE_POLYGON class defined by a sequence of @{Wrapper.Group#GROUP} waypoints within the Mission Editor, forming a polygon.
--- This class implements the inherited functions from @{Core.Zone#ZONE_RADIUS} taking into account the own zone format and properties.
+-- This class implements the inherited functions from @{#ZONE_RADIUS} taking into account the own zone format and properties.
 --
 -- ## Declare a ZONE_POLYGON directly in the DCS mission editor!
 --
@@ -2724,7 +2694,7 @@ function ZONE_POLYGON:GetScannedSetScenery()
 end
 
 --- Is All in Zone of Coalition?
--- Check if only the specifed coalition is inside the zone and noone else.
+-- Check if only the specified coalition is inside the zone and noone else.
 -- @param #ZONE_POLYGON self
 -- @param #number Coalition Coalition ID of the coalition which is checked to be the only one in the zone.
 -- @return #boolean True, if **only** that coalition is inside the zone and no one else.
@@ -2750,11 +2720,11 @@ function ZONE_POLYGON:IsAllInZoneOfOtherCoalition( Coalition )
 end
 
 --- Is Some in Zone of Coalition?
--- Check if more than one coaltion is inside the zone and the specifed coalition is one of them.
+-- Check if more than one coalition is inside the zone and the specified coalition is one of them.
 -- You first need to use the @{#ZONE_POLYGON.Scan} method to scan the zone before it can be evaluated!
 -- Note that once a zone has been scanned, multiple evaluations can be done on the scan result set.
 -- @param #ZONE_POLYGON self
--- @param #number Coalition ID of the coaliton which is checked to be inside the zone.
+-- @param #number Coalition ID of the coalition which is checked to be inside the zone.
 -- @return #boolean True if more than one coalition is inside the zone and the specified coalition is one of them.
 -- @usage
 --    self.Zone:Scan()
@@ -2999,7 +2969,7 @@ do -- ZONE_AIRBASE
 
 
   --- The ZONE_AIRBASE class defines by a zone around a @{Wrapper.Airbase#AIRBASE} with a radius.
-  -- This class implements the inherited functions from @{Core.Zone#ZONE_RADIUS} taking into account the own zone format and properties.
+  -- This class implements the inherited functions from @{#ZONE_RADIUS} taking into account the own zone format and properties.
   --
   -- @field #ZONE_AIRBASE
   ZONE_AIRBASE = {
@@ -3085,6 +3055,5 @@ do -- ZONE_AIRBASE
 
     return PointVec2
   end
-
 
 end

--- a/Moose Development/Moose/Functional/Detection.lua
+++ b/Moose Development/Moose/Functional/Detection.lua
@@ -2436,7 +2436,7 @@ do -- DETECTION_AREAS
 
   --- @type DETECTION_AREAS
   -- @field DCS#Distance DetectionZoneRange The range till which targets are grouped upon the first detected target.
-  -- @field #DETECTION_BASE.DetectedItems DetectedItems A list of areas containing the set of @{Wrapper.Unit}s, @{Zone}s, the center @{Wrapper.Unit} within the zone, and ID of each area that was detected within a DetectionZoneRange.
+  -- @field #DETECTION_BASE.DetectedItems DetectedItems A list of areas containing the set of @{Wrapper.Unit}s, @{Core.Zone}s, the center @{Wrapper.Unit} within the zone, and ID of each area that was detected within a DetectionZoneRange.
   -- @extends Functional.Detection#DETECTION_BASE
 
   --- Detect units within the battle zone for a list of @{Wrapper.Group}s detecting targets following (a) detection method(s),

--- a/Moose Development/Moose/Functional/DetectionZones.lua
+++ b/Moose Development/Moose/Functional/DetectionZones.lua
@@ -6,7 +6,7 @@ do -- DETECTION_ZONES
 
   --- @type DETECTION_ZONES
   -- @field DCS#Distance DetectionZoneRange The range till which targets are grouped upon the first detected target.
-  -- @field #DETECTION_BASE.DetectedItems DetectedItems A list of areas containing the set of @{Wrapper.Unit}s, @{Zone}s, the center @{Wrapper.Unit} within the zone, and ID of each area that was detected within a DetectionZoneRange.
+  -- @field #DETECTION_BASE.DetectedItems DetectedItems A list of areas containing the set of @{Wrapper.Unit}s, @{Core.Zone}s, the center @{Wrapper.Unit} within the zone, and ID of each area that was detected within a DetectionZoneRange.
   -- @extends Functional.Detection#DETECTION_BASE
 
   --- (old, to be revised ) Detect units within the battle zone for a list of @{Core.Zone}s detecting targets following (a) detection method(s), 

--- a/Moose Development/Moose/Functional/Mantis.lua
+++ b/Moose Development/Moose/Functional/Mantis.lua
@@ -214,7 +214,7 @@
 --  * grouping = 5000 (meters) - Detection (EWR) will group enemy flights to areas of 5km for tracking - `MANTIS:SetEWRGrouping(radius)`
 --  * detectinterval = 30 (seconds) - MANTIS will decide every 30 seconds which SAM to activate - `MANTIS:SetDetectInterval(interval)`
 --  * engagerange = 95 (percent) - SAMs will only fire if flights are inside of a 95% radius of their max firerange - `MANTIS:SetSAMRange(range)`
---  * dynamic = false - Group filtering is set to once, i.e. newly added groups will not be part of the setup by default - `MANTIS:New(name,samprefix,ewrprefix,hq,coaltion,dynamic)`
+--  * dynamic = false - Group filtering is set to once, i.e. newly added groups will not be part of the setup by default - `MANTIS:New(name,samprefix,ewrprefix,hq,coalition,dynamic)`
 --  * autorelocate = false - HQ and (mobile) EWR system will not relocate in random intervals between 30mins and 1 hour - `MANTIS:SetAutoRelocate(hq, ewr)`
 --  * debug = false - Debugging reports on screen are set to off - `MANTIS:Debug(onoff)`
 --
@@ -424,7 +424,7 @@ do
   --@param #string samprefix Prefixes for the SAM groups from the ME, e.g. all groups starting with "Red Sam..."
   --@param #string ewrprefix Prefixes for the EWR groups from the ME, e.g. all groups starting with "Red EWR..."
   --@param #string hq Group name of your HQ (optional)
-  --@param #string coaltion Coalition side of your setup, e.g. "blue", "red" or "neutral"
+  --@param #string coalition Coalition side of your setup, e.g. "blue", "red" or "neutral"
   --@param #boolean dynamic Use constant (true) filtering or just filter once (false, default) (optional)
   --@param #string awacs Group name of your Awacs (optional)
   --@param #boolean EmOnOff Make MANTIS switch Emissions on and off instead of changing the alarm state between RED and GREEN (optional)
@@ -447,7 +447,7 @@ do
   --        mybluemantis = MANTIS:New("bluemantis","Blue SAM","Blue EWR",nil,"blue",false,"Blue Awacs")
   --        mybluemantis:Start()
   --
-  function MANTIS:New(name,samprefix,ewrprefix,hq,coaltion,dynamic,awacs, EmOnOff, Padding)
+  function MANTIS:New(name,samprefix,ewrprefix,hq,coalition,dynamic,awacs, EmOnOff, Padding)
 
     -- DONE: Create some user functions for these
     -- DONE: Make HQ useful
@@ -460,7 +460,7 @@ do
     self.SAM_Templates_Prefix = samprefix or "Red SAM"
     self.EWR_Templates_Prefix = ewrprefix or "Red EWR"
     self.HQ_Template_CC = hq or nil
-    self.Coalition = coaltion or "red"
+    self.Coalition = coalition or "red"
     self.SAM_Table = {}
     self.SAM_Table_Long = {}
     self.SAM_Table_Medium = {}

--- a/Moose Development/Moose/Functional/RAT.lua
+++ b/Moose Development/Moose/Functional/RAT.lua
@@ -5443,7 +5443,7 @@ function RAT:_ModifySpawnTemplate(waypoints, livery, spawnplace, departure, take
           SpawnTemplate.units[UnitID]["onboard_num"] = string.format("%s%d%02d", self.onboardnum, (self.SpawnIndex-1)%10, (self.onboardnum0-1)+UnitID)
         end
 
-        -- Modify coaltion and country of template.
+        -- Modify coalition and country of template.
         SpawnTemplate.CoalitionID=self.coalition
         if self.country then
           SpawnTemplate.CountryID=self.country

--- a/Moose Development/Moose/Functional/Scoring.lua
+++ b/Moose Development/Moose/Functional/Scoring.lua
@@ -59,7 +59,7 @@
 --
 -- ![Banner Image](..\Presentations\SCORING\Dia9.JPG)
 --
--- Various @{Zone}s can be defined for which scores are also granted when objects in that @{Zone} are destroyed.
+-- Various @{Core.Zone}s can be defined for which scores are also granted when objects in that @{Core.Zone} are destroyed.
 -- This is **specifically useful** to designate **scenery targets on the map** that will generate points when destroyed.
 --
 -- With a small change in MissionScripting.lua, the scoring results can also be logged in a **CSV file**.
@@ -131,11 +131,11 @@
 -- # Define destruction zones that will give extra scores:
 --
 -- Define zones of destruction. Any object destroyed within the zone of the given category will give extra points.
--- Use the method @{#SCORING.AddZoneScore}() to add a @{Zone} for additional scoring.
--- Use the method @{#SCORING.RemoveZoneScore}() to remove a @{Zone} for additional scoring.
--- There are interesting variations that can be achieved with this functionality. For example, if the @{Zone} is a @{Core.Zone#ZONE_UNIT},
--- then the zone is a moving zone, and anything destroyed within that @{Zone} will generate points.
--- The other implementation could be to designate a scenery target (a building) in the mission editor surrounded by a @{Zone},
+-- Use the method @{#SCORING.AddZoneScore}() to add a @{Core.Zone} for additional scoring.
+-- Use the method @{#SCORING.RemoveZoneScore}() to remove a @{Core.Zone} for additional scoring.
+-- There are interesting variations that can be achieved with this functionality. For example, if the @{Core.Zone} is a @{Core.Zone#ZONE_UNIT},
+-- then the zone is a moving zone, and anything destroyed within that @{Core.Zone} will generate points.
+-- The other implementation could be to designate a scenery target (a building) in the mission editor surrounded by a @{Core.Zone},
 -- just large enough around that building.
 --
 -- # Add extra Goal scores upon an event or a condition:
@@ -419,11 +419,11 @@ function SCORING:AddScoreGroup( ScoreGroup, Score )
   return self
 end
 
---- Add a @{Zone} to define additional scoring when any object is destroyed in that zone.
--- Note that if a @{Zone} with the same name is already within the scoring added, the @{Zone} (type) and Score will be replaced!
+--- Add a @{Core.Zone} to define additional scoring when any object is destroyed in that zone.
+-- Note that if a @{Core.Zone} with the same name is already within the scoring added, the @{Core.Zone} (type) and Score will be replaced!
 -- This allows for a dynamic destruction zone evolution within your mission.
 -- @param #SCORING self
--- @param Core.Zone#ZONE_BASE ScoreZone The @{Zone} which defines the destruction score perimeters.
+-- @param Core.Zone#ZONE_BASE ScoreZone The @{Core.Zone} which defines the destruction score perimeters.
 -- Note that a zone can be a polygon or a moving zone.
 -- @param #number Score The Score value.
 -- @return #SCORING
@@ -438,11 +438,11 @@ function SCORING:AddZoneScore( ScoreZone, Score )
   return self
 end
 
---- Remove a @{Zone} for additional scoring.
--- The scoring will search if any @{Zone} is added with the given name, and will remove that zone from the scoring.
+--- Remove a @{Core.Zone} for additional scoring.
+-- The scoring will search if any @{Core.Zone} is added with the given name, and will remove that zone from the scoring.
 -- This allows for a dynamic destruction zone evolution within your mission.
 -- @param #SCORING self
--- @param Core.Zone#ZONE_BASE ScoreZone The @{Zone} which defines the destruction score perimeters.
+-- @param Core.Zone#ZONE_BASE ScoreZone The @{Core.Zone} which defines the destruction score perimeters.
 -- Note that a zone can be a polygon or a moving zone.
 -- @return #SCORING
 function SCORING:RemoveZoneScore( ScoreZone )

--- a/Moose Development/Moose/Functional/Warehouse.lua
+++ b/Moose Development/Moose/Functional/Warehouse.lua
@@ -6814,7 +6814,7 @@ function WAREHOUSE:_OnEventBaseCaptured(EventData)
           self:AirbaseRecaptured(NewCoalitionAirbase)
         end
       else
-        -- Captured airbase belongs to this warehouse but was captured by other coaltion.
+        -- Captured airbase belongs to this warehouse but was captured by other coalition.
         if NewCoalitionAirbase ~= self:GetCoalition() then
           self:AirbaseCaptured(NewCoalitionAirbase)
         end
@@ -7007,7 +7007,7 @@ function WAREHOUSE:_CheckRequestConsistancy(queue)
 
     -- Request from enemy coalition?
     if self:GetCoalition()~=request.warehouse:GetCoalition() then
-      self:E(self.lid..string.format("ERROR: INVALID request. Requesting warehouse is of wrong coaltion! Own coalition %s != %s of requesting warehouse.", self:GetCoalitionName(), request.warehouse:GetCoalitionName()))
+      self:E(self.lid..string.format("ERROR: INVALID request. Requesting warehouse is of wrong coalition! Own coalition %s != %s of requesting warehouse.", self:GetCoalitionName(), request.warehouse:GetCoalitionName()))
       valid=false
     end
 

--- a/Moose Development/Moose/Functional/ZoneCaptureCoalition.lua
+++ b/Moose Development/Moose/Functional/ZoneCaptureCoalition.lua
@@ -68,7 +68,7 @@ do -- ZONE_CAPTURE_COALITION
   -- 
   -- In order to use ZONE_CAPTURE_COALITION, you need to:
   -- 
-  --   * Create a @{Zone} object from one of the ZONE_ classes.    
+  --   * Create a @{Core.Zone} object from one of the ZONE_ classes.    
   --     The functional ZONE_ classses are those derived from a ZONE_RADIUS.
   --     In order to use a ZONE_POLYGON, hand over the **GROUP name** of a late activated group forming a polygon with it's waypoints.
   --   * Set the state of the zone. Most of the time, Guarded would be the initial state.
@@ -363,7 +363,7 @@ do -- ZONE_CAPTURE_COALITION
 
   --- ZONE_CAPTURE_COALITION Constructor.
   -- @param #ZONE_CAPTURE_COALITION self
-  -- @param Core.Zone#ZONE Zone A @{Zone} object with the goal to be achieved. Alternatively, can be handed as the name of late activated group describing a @{ZONE_POLYGON} with its waypoints.
+  -- @param Core.Zone#ZONE Zone A @{Core.Zone} object with the goal to be achieved. Alternatively, can be handed as the name of late activated group describing a @{ZONE_POLYGON} with its waypoints.
   -- @param DCSCoalition.DCSCoalition#coalition Coalition The initial coalition owning the zone.
   -- @param #table UnitCategories Table of unit categories. See [DCS Class Unit](https://wiki.hoggitworld.com/view/DCS_Class_Unit). Default {Unit.Category.GROUND_UNIT}.
   -- @param #table ObjectCategories Table of unit categories. See [DCS Class Object](https://wiki.hoggitworld.com/view/DCS_Class_Object). Default {Object.Category.UNIT, Object.Category.STATIC}, i.e. all UNITS and STATICS.

--- a/Moose Development/Moose/Functional/ZoneGoal.lua
+++ b/Moose Development/Moose/Functional/ZoneGoal.lua
@@ -26,7 +26,6 @@ do -- Zone
   -- @field #boolean SmokeZone If true, smoke zone.
   -- @extends Core.Zone#ZONE_RADIUS
 
-
   --- Models processes that have a Goal with a defined achievement involving a Zone. 
   -- Derived classes implement the ways how the achievements can be realized.
   -- 
@@ -53,18 +52,18 @@ do -- Zone
     SmokeColor     = nil,
     SmokeZone      = nil,
   }
-  
+
   --- ZONE_GOAL Constructor.
   -- @param #ZONE_GOAL self
-  -- @param Core.Zone#ZONE_RADIUS Zone A @{Zone} object with the goal to be achieved. Alternatively, can be handed as the name of late activated group describing a @{ZONE_POLYGON} with its waypoints.
+  -- @param Core.Zone#ZONE_RADIUS Zone A @{Core.Zone} object with the goal to be achieved. Alternatively, can be handed as the name of late activated group describing a ZONE_POLYGON with its waypoints.
   -- @return #ZONE_GOAL
   function ZONE_GOAL:New( Zone )
-    
+
     BASE:I({Zone=Zone})
     local self = BASE:Inherit( self, BASE:New())
     if type(Zone) == "string" then
        self = BASE:Inherit( self, ZONE_POLYGON:NewFromGroupName(Zone) )
-    else    
+    else
         self = BASE:Inherit( self, ZONE_RADIUS:New( Zone:GetName(), Zone:GetVec2(), Zone:GetRadius() ) ) -- #ZONE_GOAL
         self:F( { Zone = Zone } )
     end
@@ -72,7 +71,7 @@ do -- Zone
     self.Goal = GOAL:New()
 
     self.SmokeTime = nil
-    
+
     -- Set smoke ON.
     self:SetSmokeZone(true)
 
@@ -86,7 +85,7 @@ do -- Zone
     -- @function [parent=#ZONE_GOAL] __DestroyedUnit
     -- @param #ZONE_GOAL self
     -- @param #number delay Delay in seconds.
-  
+
     --- DestroyedUnit Handler OnAfter for ZONE_GOAL
     -- @function [parent=#ZONE_GOAL] OnAfterDestroyedUnit
     -- @param #ZONE_GOAL self
@@ -98,22 +97,21 @@ do -- Zone
 
     return self
   end
-  
+
   --- Get the Zone.
   -- @param #ZONE_GOAL self
   -- @return #ZONE_GOAL
   function ZONE_GOAL:GetZone()
     return self
   end
-  
-  
+
+
   --- Get the name of the Zone.
   -- @param #ZONE_GOAL self
   -- @return #string
   function ZONE_GOAL:GetZoneName()
     return self:GetName()
   end
-
 
   --- Activate smoking of zone with the color or the current owner.
   -- @param #ZONE_GOAL self
@@ -136,18 +134,16 @@ do -- Zone
   -- @param DCS#SMOKECOLOR.Color SmokeColor
   function ZONE_GOAL:Smoke( SmokeColor ) 
     self:F( { SmokeColor = SmokeColor} )
-  
+
     self.SmokeColor = SmokeColor
   end
-    
-  
+
   --- Flare the zone boundary.
   -- @param #ZONE_GOAL self
   -- @param DCS#SMOKECOLOR.Color FlareColor
   function ZONE_GOAL:Flare( FlareColor )
     self:FlareZone( FlareColor, 30)
   end
-
 
   --- When started, check the Smoke and the Zone status.
   -- @param #ZONE_GOAL self
@@ -160,17 +156,16 @@ do -- Zone
     end
   end
 
-
   --- Check status Smoke.
   -- @param #ZONE_GOAL self
   function ZONE_GOAL:StatusSmoke()
     self:F({self.SmokeTime, self.SmokeColor})
-    
+
     if self.SmokeZone then
-    
+
       -- Current time.
       local CurrentTime = timer.getTime()
-    
+
       -- Restart smoke every 5 min.
       if self.SmokeTime == nil or self.SmokeTime + 300 <= CurrentTime then
         if self.SmokeColor then
@@ -178,11 +173,10 @@ do -- Zone
           self.SmokeTime = CurrentTime
         end
       end
-      
-    end
-    
-  end
 
+    end
+
+  end
 
   --- @param #ZONE_GOAL self
   -- @param Core.Event#EVENTDATA EventData Event data table.
@@ -190,38 +184,37 @@ do -- Zone
     self:F( { "EventDead", EventData } )
 
     self:F( { EventData.IniUnit } )
-    
+
     if EventData.IniDCSUnit then
 
       local Vec3 = EventData.IniDCSUnit:getPosition().p
       self:F( { Vec3 = Vec3 } )    
-    
+
       if Vec3 and self:IsVec3InZone(Vec3)  then
-      
+
         local PlayerHits = _DATABASE.HITS[EventData.IniUnitName]
-        
+
         if PlayerHits then
-        
+
           for PlayerName, PlayerHit in pairs( PlayerHits.Players or {} ) do
             self.Goal:AddPlayerContribution( PlayerName )
             self:DestroyedUnit( EventData.IniUnitName, PlayerName )
           end
-          
+
         end
-        
+
       end
     end
-    
+
   end
-  
-  
+
   --- Activate the event UnitDestroyed to be fired when a unit is destroyed in the zone.
   -- @param #ZONE_GOAL self
   function ZONE_GOAL:MonitorDestroyedUnits()
 
     self:HandleEvent( EVENTS.Dead,  self.__Destroyed )
     self:HandleEvent( EVENTS.Crash, self.__Destroyed )
-  
+
   end
-  
+
 end

--- a/Moose Development/Moose/Functional/ZoneGoalCargo.lua
+++ b/Moose Development/Moose/Functional/ZoneGoalCargo.lua
@@ -55,7 +55,7 @@ do -- ZoneGoal
   
   --- ZONE_GOAL_CARGO Constructor.
   -- @param #ZONE_GOAL_CARGO self
-  -- @param Core.Zone#ZONE Zone A @{Zone} object with the goal to be achieved.
+  -- @param Core.Zone#ZONE Zone A @{Core.Zone} object with the goal to be achieved.
   -- @param DCSCoalition.DCSCoalition#coalition Coalition The initial coalition owning the zone.
   -- @return #ZONE_GOAL_CARGO
   function ZONE_GOAL_CARGO:New( Zone, Coalition )

--- a/Moose Development/Moose/Functional/ZoneGoalCoalition.lua
+++ b/Moose Development/Moose/Functional/ZoneGoalCoalition.lua
@@ -53,7 +53,7 @@ do -- ZoneGoal
 
   --- ZONE_GOAL_COALITION Constructor.
   -- @param #ZONE_GOAL_COALITION self
-  -- @param Core.Zone#ZONE Zone A @{Zone} object with the goal to be achieved.
+  -- @param Core.Zone#ZONE Zone A @{Core.Zone} object with the goal to be achieved.
   -- @param DCSCoalition.DCSCoalition#coalition Coalition The initial coalition owning the zone. Default coalition.side.NEUTRAL.
   -- @param #table UnitCategories Table of unit categories. See [DCS Class Unit](https://wiki.hoggitworld.com/view/DCS_Class_Unit). Default {Unit.Category.GROUND_UNIT}.
   -- @return #ZONE_GOAL_COALITION

--- a/Moose Development/Moose/Ops/Airboss.lua
+++ b/Moose Development/Moose/Ops/Airboss.lua
@@ -297,7 +297,7 @@
 --
 -- The flight that transitions form the holding pattern to the landing approach, it should leave the Marshal stack at the 3 position and make a left hand turn to the *Initial*
 -- position, which is 3 NM astern of the boat. Note that you need to be below 1300 feet to be registered in the initial zone.
--- The altitude can be set via the function @{AIRBOSS.SetInitialMaxAlt}(*altitude*) function.
+-- The altitude can be set via the function @{#AIRBOSS.SetInitialMaxAlt}(*altitude*) function.
 -- As described below, the initial zone can be smoked or flared via the AIRBOSS F10 Help radio menu.
 --
 -- ### Landing Pattern
@@ -762,7 +762,7 @@
 --
 -- ## Save Results
 --
--- Saving asset data to file is achieved by the @{AIRBOSS.Save}(*path*, *filename*) function.
+-- Saving asset data to file is achieved by the @{#AIRBOSS.Save}(*path*, *filename*) function.
 --
 -- The parameter *path* specifies the path on the file system where the
 -- player grades are saved. If you do not specify a path, the file is saved your the DCS installation root directory if the **lfs** module is *not* desanizied or
@@ -783,7 +783,7 @@
 --
 -- ### Automatic Saving
 --
--- The player grades can be saved automatically after each graded player pass via the @{AIRBOSS.SetAutoSave}(*path*, *filename*) function. Again the parameters *path* and *filename* are optional.
+-- The player grades can be saved automatically after each graded player pass via the @{#AIRBOSS.SetAutoSave}(*path*, *filename*) function. Again the parameters *path* and *filename* are optional.
 -- In the simplest case, you desanitize the **lfs** module and just add
 --
 --     airbossStennis:SetAutoSave()
@@ -821,7 +821,7 @@
 --
 -- ## Load Results
 --
--- Loading player grades from file is achieved by the @{AIRBOSS.Load}(*path*, *filename*) function. The parameter *path* specifies the path on the file system where the
+-- Loading player grades from file is achieved by the @{#AIRBOSS.Load}(*path*, *filename*) function. The parameter *path* specifies the path on the file system where the
 -- data is loaded from. If you do not specify a path, the file is loaded from your the DCS installation root directory or, if **lfs** was desanitized from you "Saved Games\DCS" directory.
 -- The parameter *filename* is optional and defines the name of the file to load. By default this is automatically generated from the AIBOSS carrier name/alias, for example
 -- "Airboss-USS Stennis_LSOgrades.csv".
@@ -1041,7 +1041,7 @@
 --
 -- AI groups that enter the CCA are usually guided to Marshal stack. However, due to DCS limitations they might not obey the landing task if they have another airfield as departure and/or destination in
 -- their mission task. Therefore, AI groups can be respawned when detected in the CCA. This should clear all other airfields and allow the aircraft to land on the carrier.
--- This is achieved by the @{AIRBOSS.SetRespawnAI}() function.
+-- This is achieved by the @{#AIRBOSS.SetRespawnAI}() function.
 --
 -- ## Known Issues
 --

--- a/Moose Development/Moose/Tasking/Mission.lua
+++ b/Moose Development/Moose/Tasking/Mission.lua
@@ -86,7 +86,7 @@
 --   - @{#MISSION.GetTasks}(): Retrieves a list of the tasks controlled by the mission.
 --   - @{#MISSION.GetTask}(): Retrieves a specific task controlled by the mission.
 --   - @{#MISSION.GetTasksRemaining}(): Retrieve a list of the tasks that aren't finished or failed, and are governed by the mission.
---   - @{#MISSION.GetGroupTasks}(): Retrieve a list of the tasks that can be asigned to a @{Wrapper.Group}.
+--   - @{#MISSION.GetGroupTasks}(): Retrieve a list of the tasks that can be assigned to a @{Wrapper.Group}.
 --   - @{#MISSION.GetTaskTypes}(): Retrieve a list of the different task types governed by the mission.
 -- 
 -- ### 3.3. Get the command center.

--- a/Moose Development/Moose/Tasking/Task_Manager.lua
+++ b/Moose Development/Moose/Tasking/Task_Manager.lua
@@ -33,7 +33,7 @@
 -- @image MOOSE.JPG
 
 do -- TASK_MANAGER
-  
+
   --- TASK_MANAGER class.
   -- @type TASK_MANAGER
   -- @field Core.Set#SET_GROUP SetGroup The set of group objects containing players for which tasks are managed.
@@ -42,21 +42,21 @@ do -- TASK_MANAGER
     ClassName = "TASK_MANAGER",
     SetGroup = nil,
   }
-  
+
   --- TASK\_MANAGER constructor.
   -- @param #TASK_MANAGER self
   -- @param Core.Set#SET_GROUP SetGroup The set of group objects containing players for which tasks are managed.
   -- @return #TASK_MANAGER self
   function TASK_MANAGER:New( SetGroup )
-  
+
     -- Inherits from BASE
     local self = BASE:Inherit( self, FSM:New() ) -- #TASK_MANAGER
-    
+
     self.SetGroup = SetGroup
-    
+
     self:SetStartState( "Stopped" )
     self:AddTransition( "Stopped", "StartTasks", "Started" )
-    
+
     --- StartTasks Handler OnBefore for TASK_MANAGER
     -- @function [parent=#TASK_MANAGER] OnBeforeStartTasks
     -- @param #TASK_MANAGER self
@@ -64,27 +64,25 @@ do -- TASK_MANAGER
     -- @param #string Event
     -- @param #string To
     -- @return #boolean
-    
+
     --- StartTasks Handler OnAfter for TASK_MANAGER
     -- @function [parent=#TASK_MANAGER] OnAfterStartTasks
     -- @param #TASK_MANAGER self
     -- @param #string From
     -- @param #string Event
     -- @param #string To
-    
+
     --- StartTasks Trigger for TASK_MANAGER
     -- @function [parent=#TASK_MANAGER] StartTasks
     -- @param #TASK_MANAGER self
-    
+
     --- StartTasks Asynchronous Trigger for TASK_MANAGER
     -- @function [parent=#TASK_MANAGER] __StartTasks
     -- @param #TASK_MANAGER self
     -- @param #number Delay
-    
-    
-    
+
     self:AddTransition( "Started", "StopTasks", "Stopped" )
-    
+
     --- StopTasks Handler OnBefore for TASK_MANAGER
     -- @function [parent=#TASK_MANAGER] OnBeforeStopTasks
     -- @param #TASK_MANAGER self
@@ -92,28 +90,27 @@ do -- TASK_MANAGER
     -- @param #string Event
     -- @param #string To
     -- @return #boolean
-    
+
     --- StopTasks Handler OnAfter for TASK_MANAGER
     -- @function [parent=#TASK_MANAGER] OnAfterStopTasks
     -- @param #TASK_MANAGER self
     -- @param #string From
     -- @param #string Event
     -- @param #string To
-    
+
     --- StopTasks Trigger for TASK_MANAGER
     -- @function [parent=#TASK_MANAGER] StopTasks
     -- @param #TASK_MANAGER self
-    
+
     --- StopTasks Asynchronous Trigger for TASK_MANAGER
     -- @function [parent=#TASK_MANAGER] __StopTasks
     -- @param #TASK_MANAGER self
     -- @param #number Delay
-    
 
     self:AddTransition( "Started", "Manage", "Started" )
 
     self:AddTransition( "Started", "Success", "Started" )
-    
+
     --- Success Handler OnAfter for TASK_MANAGER
     -- @function [parent=#TASK_MANAGER] OnAfterSuccess
     -- @param #TASK_MANAGER self
@@ -121,10 +118,9 @@ do -- TASK_MANAGER
     -- @param #string Event
     -- @param #string To
     -- @param Tasking.Task#TASK Task
-    
-    
+
     self:AddTransition( "Started", "Failed", "Started" )
-    
+
     --- Failed Handler OnAfter for TASK_MANAGER
     -- @function [parent=#TASK_MANAGER] OnAfterFailed
     -- @param #TASK_MANAGER self
@@ -132,10 +128,9 @@ do -- TASK_MANAGER
     -- @param #string Event
     -- @param #string To
     -- @param Tasking.Task#TASK Task
-    
-    
+
     self:AddTransition( "Started", "Aborted", "Started" )
-    
+
     --- Aborted Handler OnAfter for TASK_MANAGER
     -- @function [parent=#TASK_MANAGER] OnAfterAborted
     -- @param #TASK_MANAGER self
@@ -143,9 +138,9 @@ do -- TASK_MANAGER
     -- @param #string Event
     -- @param #string To
     -- @param Tasking.Task#TASK Task
-    
+
     self:AddTransition( "Started", "Cancelled", "Started" )
-    
+
     --- Cancelled Handler OnAfter for TASK_MANAGER
     -- @function [parent=#TASK_MANAGER] OnAfterCancelled
     -- @param #TASK_MANAGER self
@@ -155,37 +150,37 @@ do -- TASK_MANAGER
     -- @param Tasking.Task#TASK Task
 
     self:SetRefreshTimeInterval( 30 )
-  
+
     return self
   end
-  
+
   function TASK_MANAGER:onafterStartTasks( From, Event, To )
     self:Manage()
   end
-  
+
   function TASK_MANAGER:onafterManage( From, Event, To )
 
     self:__Manage( -self._RefreshTimeInterval )
 
     self:ManageTasks()
   end
-  
+
   --- Set the refresh time interval in seconds when a new task management action needs to be done.
   -- @param #TASK_MANAGER self
   -- @param #number RefreshTimeInterval The refresh time interval in seconds when a new task management action needs to be done.
   -- @return #TASK_MANAGER self
   function TASK_MANAGER:SetRefreshTimeInterval( RefreshTimeInterval )
     self:F2()
-  
+
     self._RefreshTimeInterval = RefreshTimeInterval
   end
-  
-  
+
+
   --- Manages the tasks for the @{Core.Set#SET_GROUP}.
   -- @param #TASK_MANAGER self
   -- @return #TASK_MANAGER self
   function TASK_MANAGER:ManageTasks()
-  
+
   end
 
 end

--- a/Moose Development/Moose/Utilities/Utils.lua
+++ b/Moose Development/Moose/Utilities/Utils.lua
@@ -1412,7 +1412,7 @@ function UTILS.CheckMemory(output)
 end
 
 
---- Get the coalition name from its numerical ID, e.g. coaliton.side.RED.
+--- Get the coalition name from its numerical ID, e.g. coalition.side.RED.
 -- @param #number Coalition The coalition ID.
 -- @return #string The coalition name, i.e. "Neutral", "Red" or "Blue" (or "Unknown").
 function UTILS.GetCoalitionName(Coalition)

--- a/Moose Development/Moose/Wrapper/Controllable.lua
+++ b/Moose Development/Moose/Wrapper/Controllable.lua
@@ -3635,7 +3635,7 @@ end
 
 --- Retrieve the controllable mission and allow to place function hooks within the mission waypoint plan.
 -- Use the method @{#CONTROLLABLE.WayPointFunction}() to define the hook functions for specific waypoints.
--- Use the method @{#CONTROLLABLE.WayPointExecute)() to start the execution of the new mission plan.
+-- Use the method @{#CONTROLLABLE.WayPointExecute}() to start the execution of the new mission plan.
 -- Note that when WayPointInitialize is called, the Mission of the controllable is RESTARTED!
 -- @param #CONTROLLABLE self
 -- @param #table WayPoints If WayPoints is given, then use the route.

--- a/Moose Development/Moose/Wrapper/Group.lua
+++ b/Moose Development/Moose/Wrapper/Group.lua
@@ -132,14 +132,14 @@
 -- 
 -- ## GROUP Zone validation methods
 -- 
--- The group can be validated whether it is completely, partly or not within a @{Zone}.
+-- The group can be validated whether it is completely, partly or not within a @{Core.Zone}.
 -- Use the following Zone validation methods on the group:
 -- 
---   * @{#GROUP.IsCompletelyInZone}: Returns true if all units of the group are within a @{Zone}.
---   * @{#GROUP.IsPartlyInZone}: Returns true if some units of the group are within a @{Zone}.
---   * @{#GROUP.IsNotInZone}: Returns true if none of the group units of the group are within a @{Zone}.
+--   * @{#GROUP.IsCompletelyInZone}: Returns true if all units of the group are within a @{Core.Zone}.
+--   * @{#GROUP.IsPartlyInZone}: Returns true if some units of the group are within a @{Core.Zone}.
+--   * @{#GROUP.IsNotInZone}: Returns true if none of the group units of the group are within a @{Core.Zone}.
 --   
--- The zone can be of any @{Zone} class derived from @{Core.Zone#ZONE_BASE}. So, these methods are polymorphic to the zones tested on.
+-- The zone can be of any @{Core.Zone} class derived from @{Core.Zone#ZONE_BASE}. So, these methods are polymorphic to the zones tested on.
 -- 
 -- ## GROUP AI methods
 -- 
@@ -1295,7 +1295,7 @@ end
 do -- Is Zone methods
 
 
---- Check if any unit of a group is inside a @{Zone}.
+--- Check if any unit of a group is inside a @{Core.Zone}.
 -- @param #GROUP self
 -- @param Core.Zone#ZONE_BASE Zone The zone to test.
 -- @return #boolean Returns `true` if *at least one unit* is inside the zone or `false` if *no* unit is inside.
@@ -1324,7 +1324,7 @@ function GROUP:IsInZone( Zone )
   return nil
 end
 
---- Returns true if all units of the group are within a @{Zone}.
+--- Returns true if all units of the group are within a @{Core.Zone}.
 -- @param #GROUP self
 -- @param Core.Zone#ZONE_BASE Zone The zone to test.
 -- @return #boolean Returns true if the Group is completely within the @{Core.Zone#ZONE_BASE}
@@ -1344,7 +1344,7 @@ function GROUP:IsCompletelyInZone( Zone )
   return true
 end
 
---- Returns true if some but NOT ALL units of the group are within a @{Zone}.
+--- Returns true if some but NOT ALL units of the group are within a @{Core.Zone}.
 -- @param #GROUP self
 -- @param Core.Zone#ZONE_BASE Zone The zone to test.
 -- @return #boolean Returns true if the Group is partially within the @{Core.Zone#ZONE_BASE}
@@ -1372,7 +1372,7 @@ function GROUP:IsPartlyInZone( Zone )
   end
 end
 
---- Returns true if part or all units of the group are within a @{Zone}.
+--- Returns true if part or all units of the group are within a @{Core.Zone}.
 -- @param #GROUP self
 -- @param Core.Zone#ZONE_BASE Zone The zone to test.
 -- @return #boolean Returns true if the Group is partially or completely within the @{Core.Zone#ZONE_BASE}.
@@ -1380,7 +1380,7 @@ function GROUP:IsPartlyOrCompletelyInZone( Zone )
   return self:IsPartlyInZone(Zone) or self:IsCompletelyInZone(Zone)
 end
 
---- Returns true if none of the group units of the group are within a @{Zone}.
+--- Returns true if none of the group units of the group are within a @{Core.Zone}.
 -- @param #GROUP self
 -- @param Core.Zone#ZONE_BASE Zone The zone to test.
 -- @return #boolean Returns true if the Group is not within the @{Core.Zone#ZONE_BASE}
@@ -1416,10 +1416,10 @@ function GROUP:IsAnyInZone( Zone )
   return false
 end
 
---- Returns the number of UNITs that are in the @{Zone}
+--- Returns the number of UNITs that are in the @{Core.Zone}
 -- @param #GROUP self
 -- @param Core.Zone#ZONE_BASE Zone The zone to test.
--- @return #number The number of UNITs that are in the @{Zone}
+-- @return #number The number of UNITs that are in the @{Core.Zone}
 function GROUP:CountInZone( Zone )
   self:F2( {self.GroupName, Zone} )
   local Count = 0
@@ -1742,7 +1742,7 @@ function GROUP:InitHeight( Height )
 end
 
 
---- Set the respawn @{Zone} for the respawned group.
+--- Set the respawn @{Core.Zone} for the respawned group.
 -- @param #GROUP self
 -- @param Core.Zone#ZONE Zone The zone in meters.
 -- @return #GROUP self
@@ -1752,7 +1752,7 @@ function GROUP:InitZone( Zone )
 end
 
 
---- Randomize the positions of the units of the respawned group within the @{Zone}.
+--- Randomize the positions of the units of the respawned group within the @{Core.Zone}.
 -- When a Respawn happens, the units of the group will be placed at random positions within the Zone (selected).
 -- @param #GROUP self
 -- @param #boolean PositionZone true will randomize the positions within the Zone.
@@ -1852,9 +1852,9 @@ end
 --   - @{#GROUP.InitHeading}: Set the heading for the units in degrees within the respawned group.
 --   - @{#GROUP.InitHeight}: Set the height for the units in meters for the respawned group. (This is applicable for air units).
 --   - @{#GROUP.InitRandomizeHeading}: Randomize the headings for the units within the respawned group.
---   - @{#GROUP.InitZone}: Set the respawn @{Zone} for the respawned group.
---   - @{#GROUP.InitRandomizeZones}: Randomize the respawn @{Zone} between one of the @{Zone}s given for the respawned group.
---   - @{#GROUP.InitRandomizePositionZone}: Randomize the positions of the units of the respawned group within the @{Zone}.
+--   - @{#GROUP.InitZone}: Set the respawn @{Core.Zone} for the respawned group.
+--   - @{#GROUP.InitRandomizeZones}: Randomize the respawn @{Core.Zone} between one of the @{Core.Zone}s given for the respawned group.
+--   - @{#GROUP.InitRandomizePositionZone}: Randomize the positions of the units of the respawned group within the @{Core.Zone}.
 --   - @{#GROUP.InitRandomizePositionRadius}: Randomize the positions of the units of the respawned group in a circle band.
 --   - @{#GROUP.InitRandomizeTemplates}: Randomize the Template for the respawned group.
 -- 

--- a/Moose Development/Moose/Wrapper/Positionable.lua
+++ b/Moose Development/Moose/Wrapper/Positionable.lua
@@ -1815,7 +1815,7 @@ function POSITIONABLE:SmokeBlue()
   trigger.action.smoke( self:GetVec3(), trigger.smokeColor.Blue )
 end
 
---- Returns true if the unit is within a @{Zone}.
+--- Returns true if the unit is within a @{Core.Zone}.
 -- @param #POSITIONABLE self
 -- @param Core.Zone#ZONE_BASE Zone The zone to test.
 -- @return #boolean Returns true if the unit is within the @{Core.Zone#ZONE_BASE}
@@ -1830,7 +1830,7 @@ function POSITIONABLE:IsInZone( Zone )
   return false
 end
 
---- Returns true if the unit is not within a @{Zone}.
+--- Returns true if the unit is not within a @{Core.Zone}.
 -- @param #POSITIONABLE self
 -- @param Core.Zone#ZONE_BASE Zone The zone to test.
 -- @return #boolean Returns true if the unit is not within the @{Core.Zone#ZONE_BASE}


### PR DESCRIPTION
Fix documentation references.
Correct spelling errors.
Remove empty whitespaces.
Correct a single mis-spelled ZONE_BASE variable, see 'Core/Zone.lua' (variable "Sureface" -> "Surface", no references to mis-spelled "Sureface" throughout the codebase).
Correct mis-spelling of "coaltion" in 'Functional/Mantis.lua', corrected to "coalition".