### PR TITLE
Include meters in RANGE bombing result text.

### DIFF
--- a/Moose Development/Moose/Functional/Range.lua
+++ b/Moose Development/Moose/Functional/Range.lua
@@ -2259,7 +2259,7 @@ function RANGE:onafterImpact( From, Event, To, result, player )
   end
 
   -- Send message to player.
-  local text = string.format( "%s, impact %03d° for %d ft", player.playername, result.radial, UTILS.MetersToFeet( result.distance ) )
+  local text = string.format( "%s, impact %03d° for %d ft (%d m)", player.playername, result.radial, UTILS.MetersToFeet( result.distance ), result.distance )
   if targetname then
     text = text .. string.format( " from bulls of target %s.", targetname )
   else


### PR DESCRIPTION
Add meter text to RANGE bombing result. Meters is used everywhere in RANGE (including leader boards etc) except in this message and also the radio transmission (there's no sound file for meters, yet...).