### PR TITLE
F10 Marker text fix

### DIFF
--- a/Moose Development/Moose/Ops/PlayerTask.lua
+++ b/Moose Development/Moose/Ops/PlayerTask.lua
@@ -506,7 +506,7 @@ function PLAYERTASK:MarkTargetOnF10Map(Text,Coalition,ReadOnly)
         self.TargetMarker:Remove()
       end
       local text = Text or "Target of "..self.lid
-      self.TargetMarker = MARKER:New(coordinate,"Target of "..self.lid)
+      self.TargetMarker = MARKER:New(coordinate,text)
       if ReadOnly then
         self.TargetMarker:ReadOnly()
       end


### PR DESCRIPTION
PLAYERTASK:MarkTargetOnF10Map

When creating the marker on the F10 map, the marker text was defaulting back to a generic description.  Was typo oversight I would think.