### PR TITLE
OPSGROUP

### DIFF
--- a/Moose Development/Moose/DCS.lua
+++ b/Moose Development/Moose/DCS.lua
@@ -1001,8 +1001,8 @@ do -- Unit
   
   --- Enum that stores aircraft refueling system types.
   -- @type Unit.RefuelingSystem
-  -- @field BOOM_AND_RECEPTACLE
-  -- @field PROBE_AND_DROGUE
+  -- @field BOOM_AND_RECEPTACLE Tanker with a boom.
+  -- @field PROBE_AND_DROGUE Tanker with a probe.
   
   --- Enum that stores sensor types.
   -- @type Unit.SensorType

--- a/Moose Development/Moose/Ops/ArmyGroup.lua
+++ b/Moose Development/Moose/Ops/ArmyGroup.lua
@@ -1415,12 +1415,14 @@ function ARMYGROUP:onafterOutOfAmmo(From, Event, To)
   
   -- Second, check if we want to retreat once out of ammo.
   if self.retreatOnOutOfAmmo then
+    self:T(self.lid.."Retreat on out of ammo")
     self:__Retreat(-1)
     return
   end
   
-  -- Third, check if we want to RTZ once out of ammo.
-  if self.rtzOnOutOfAmmo then
+  -- Third, check if we want to RTZ once out of ammo (unless we have a rearming mission in the queue).
+  if self.rtzOnOutOfAmmo and not self:IsMissionTypeInQueue(AUFTRAG.Type.REARMING) then
+    self:T(self.lid.."RTZ on out of ammo")
     self:__RTZ(-1)
   end
     
@@ -1536,6 +1538,7 @@ end
 -- @param Core.Zone#ZONE Zone The zone to return to.
 -- @param #number Formation Formation of the group.
 function ARMYGROUP:onbeforeRTZ(From, Event, To, Zone, Formation)
+  self:T2(self.lid.."onbeforeRTZ")
 
   -- Zone.
   local zone=Zone or self.homezone
@@ -1563,6 +1566,7 @@ end
 -- @param Core.Zone#ZONE Zone The zone to return to.
 -- @param #number Formation Formation of the group.
 function ARMYGROUP:onafterRTZ(From, Event, To, Zone, Formation)
+  self:T2(self.lid.."onafterRTZ")
   
   -- Zone.
   local zone=Zone or self.homezone

--- a/Moose Development/Moose/Ops/FlightGroup.lua
+++ b/Moose Development/Moose/Ops/FlightGroup.lua
@@ -216,7 +216,7 @@ FLIGHTGROUP.Players={}
 
 --- FLIGHTGROUP class version.
 -- @field #string version
-FLIGHTGROUP.version="0.8.3"
+FLIGHTGROUP.version="0.8.4"
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 -- TODO list
@@ -2637,20 +2637,9 @@ function FLIGHTGROUP:onafterRTB(From, Event, To, airbase, SpeedTo, SpeedHold, Sp
 
   -- Set the destination base.
   self.destbase=airbase
-
+  
   -- Cancel all missions.
-  for _,_mission in pairs(self.missionqueue) do
-    local mission=_mission --Ops.Auftrag#AUFTRAG
-    local mystatus=mission:GetGroupStatus(self)
-
-    -- Check if mission is already over!
-    if not (mystatus==AUFTRAG.GroupStatus.DONE or mystatus==AUFTRAG.GroupStatus.CANCELLED) then
-      local text=string.format("Canceling mission %s in state=%s", mission.name, mission.status)
-      self:T(self.lid..text)
-      self:MissionCancel(mission)
-    end
-
-  end
+  self:CancelAllMissions()
 
   -- Land at airbase.
   self:_LandAtAirbase(airbase, SpeedTo, SpeedHold, SpeedLand)
@@ -2895,8 +2884,11 @@ function FLIGHTGROUP:_LandAtAirbase(airbase, SpeedTo, SpeedHold, SpeedLand)
     --self:ClearTasks()
 
     -- Just route the group. Respawn might happen when going from holding to final.
-    -- NOTE: I have delayed that here because of RTB calling _LandAtAirbase which resets current task immediately. So the stop flag change to 1 will not trigger TaskDone() and a current mission is not done either
-    self:Route(wp, 0.1)
+    -- NOTE: I have delayed that here because of RTB calling _LandAtAirbase which resets current task immediately. 
+    -- So the stop flag change to 1 will not trigger TaskDone() and a current mission is not done either!
+    -- Looks like a delay of 0.1 sec was not enough for the stopflag to take effect. Increasing this to 1.0 sec.
+    -- This delay is looking better. Hopefully not any unwanted side effects in other situations.
+    self:Route(wp, 1.0)
 
   end
 

--- a/Moose Development/Moose/Ops/Legion.lua
+++ b/Moose Development/Moose/Ops/Legion.lua
@@ -1068,7 +1068,8 @@ function LEGION:onafterMissionRequest(From, Event, To, Mission, Assets)
     --self:AddRequest(self, WAREHOUSE.Descriptor.ASSETLIST, Assetlist, #Assetlist, nil, nil, Mission.prio, assignment)
     local request=self:_AddRequest(WAREHOUSE.Descriptor.ASSETLIST, Assetlist, #Assetlist, Mission.prio, assignment)
     
-    env.info(string.format("FF Added request=%d for Nasssets=%d", request.uid, #Assetlist))
+    -- Debug Info.
+    self:T(self.lid..string.format("Added request=%d for Nasssets=%d", request.uid, #Assetlist))
 
     -- The queueid has been increased in the onafterAddRequest function. So we can simply use it here.
     --Mission.requestID[self.alias]=self.queueid

--- a/Moose Development/Moose/Ops/OpsGroup.lua
+++ b/Moose Development/Moose/Ops/OpsGroup.lua
@@ -4898,6 +4898,22 @@ function OPSGROUP:RemoveMission(Mission)
   return self
 end
 
+--- Cancel all missions in mission queue.
+-- @param #OPSGROUP self
+function OPSGROUP:CancelAllMissions()
+  self:T(self.lid.."Cancelling ALL missions!")
+
+  -- Cancel all missions.
+  for _,_mission in pairs(self.missionqueue) do
+    local mission=_mission --Ops.Auftrag#AUFTRAG
+    if mission:IsNotOver() then
+      self:T(self.lid.."Cancelling mission "..tostring(mission:GetName()))
+      self:MissionCancel(mission)
+    end
+  end
+
+end
+
 --- Count remaining missons.
 -- @param #OPSGROUP self
 -- @return #number Number of missions to be done.
@@ -5075,6 +5091,24 @@ function OPSGROUP:IsMissionInQueue(Mission)
     local mission=_mission --Ops.Auftrag#AUFTRAG
 
     if mission.auftragsnummer==Mission.auftragsnummer then
+      return true
+    end
+
+  end
+
+  return false
+end
+
+--- Check if a given mission type is already in the queue.
+-- @param #OPSGROUP self
+-- @param #string MissionType MissionType Type of mission.
+-- @return #boolean If `true`, the mission type is in the queue.
+function OPSGROUP:IsMissionTypeInQueue(MissionType)
+
+  for _,_mission in pairs(self.missionqueue) do
+    local mission=_mission --Ops.Auftrag#AUFTRAG
+
+    if mission:GetType()==MissionType then
       return true
     end
 
@@ -7534,21 +7568,6 @@ function OPSGROUP:onbeforeDead(From, Event, To)
   if self.Ndestroyed==#self.elements then
     self:Destroyed()
   end
-end
-
---- Cancel all missions in mission queue.
--- @param #OPSGROUP self
-function OPSGROUP:CancelAllMissions()
-
-  -- Cancel all missions.
-  for _,_mission in pairs(self.missionqueue) do
-    local mission=_mission --Ops.Auftrag#AUFTRAG
-    if mission:IsNotOver() then
-      self:T(self.lid.."Cancelling mission "..tostring(mission:GetName()))
-      self:MissionCancel(mission)
-    end
-  end
-
 end
 
 --- On after "Dead" event.
@@ -10171,8 +10190,10 @@ function OPSGROUP:_CheckGroupDone(delay)
 
             self:T(self.lid..string.format("Passed final WP, adinfinitum=FALSE, LEGION set ==> RTZ"))
             if self.isArmygroup then
+              self:T2(self.lid.."RTZ to legion spawn zone")
               self:RTZ(self.legion.spawnzone)
             elseif self.isNavygroup then
+              self:T2(self.lid.."RTZ to legion port zone")
               self:RTZ(self.legion.portzone)
             end
 
@@ -10255,6 +10276,7 @@ function OPSGROUP:_CheckStuck()
       if self:IsEngaging() then
         self:__Disengage(1)        
       elseif self:IsReturning() then
+        self:T2(self.lid.."RTZ because of stuck")
         self:__RTZ(1)
       else
         self:__Cruise(1)
@@ -10274,6 +10296,7 @@ function OPSGROUP:_CheckStuck()
       else
         -- Give cruise command again.
         if self:IsReturning() then
+          self:T2(self.lid.."RTZ because of stuck")
           self:__RTZ(1)
         else
           self:__Cruise(1)

--- a/Moose Development/Moose/Ops/OpsGroup.lua
+++ b/Moose Development/Moose/Ops/OpsGroup.lua
@@ -4898,7 +4898,7 @@ function OPSGROUP:RemoveMission(Mission)
   return self
 end
 
---- Cancel all missions in mission queue.
+--- Cancel all missions in mission queue that are not already done or cancelled.
 -- @param #OPSGROUP self
 function OPSGROUP:CancelAllMissions()
   self:T(self.lid.."Cancelling ALL missions!")
@@ -4906,7 +4906,13 @@ function OPSGROUP:CancelAllMissions()
   -- Cancel all missions.
   for _,_mission in pairs(self.missionqueue) do
     local mission=_mission --Ops.Auftrag#AUFTRAG
-    if mission:IsNotOver() then
+
+    -- Current group status.
+    local mystatus=mission:GetGroupStatus(self)
+
+    -- Check if mission is already over!
+    if not (mystatus==AUFTRAG.GroupStatus.DONE or mystatus==AUFTRAG.GroupStatus.CANCELLED) then        
+    --if mission:IsNotOver() then
       self:T(self.lid.."Cancelling mission "..tostring(mission:GetName()))
       self:MissionCancel(mission)
     end


### PR DESCRIPTION
**FLIGHTGROUP**
- Increased delay to route aircraft back home after RTB to 1.0 sec (from 0.1 sec) for stopflag to take effect. Otherwise tasks might not be done and missions also.

**ARMYGROUP**
- Groups will not RTZ on out-of-ammo if they have a REARMING mission in the queue.