### PR TITLE
Changed documentation for Marker.lua and MarkerOps_Base.lua

### DIFF
--- a/Moose Development/Moose/Core/MarkerOps_Base.lua
+++ b/Moose Development/Moose/Core/MarkerOps_Base.lua
@@ -5,6 +5,12 @@
 --    * Create an easy way to tap into markers added to the F10 map by users.
 --    * Recognize own tag and list of keywords.
 --    * Matched keywords are handed down to functions.
+-- ##Listen for your tag
+--    myMarker = MARKEROPS_BASE:New("tag", {}, false)
+--    function myMarker:OnAfterMarkChanged(From, Event, To, Text, Keywords, Coord, idx)
+--
+--    end
+-- Make sure to use the "MarkChanged" event as "MarkAdded" comes in right after the user places a blank marker and your callback will never be called.
 --
 -- ===
 --

--- a/Moose Development/Moose/Wrapper/Marker.lua
+++ b/Moose Development/Moose/Wrapper/Marker.lua
@@ -58,18 +58,16 @@
 -- If the maker should be visible to a specific coalition, you can use the :ToCoalition() function.
 --
 --     mymarker = MARKER:New( Coordinate , "I am Batumi Airfield" ):ToCoalition( coalition.side.BLUE )
---
--- ### To Blue Coalition
---
--- ### To Red Coalition
---
+--     
 -- This would show the marker only to the Blue coalition.
 --
 -- ## For a Group
 --
+--     mymarker = MARKER:New( Coordinate , "Target Location" ):ToGroup( tankGroup )
 --
 -- # Removing a Marker
---
+--     mymarker:Remove(60)
+-- This removes the marker after 60 seconds
 --
 -- # Updating a Marker
 --
@@ -305,7 +303,7 @@ end
 -- User API Functions
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
---- Marker is readonly. Text cannot be changed and marker cannot be removed.
+--- Marker is readonly. Text cannot be changed and marker cannot be removed. The will not update the marker in the game, Call MARKER:Refresh to update state.
 -- @param #MARKER self
 -- @return #MARKER self
 function MARKER:ReadOnly()
@@ -315,7 +313,7 @@ function MARKER:ReadOnly()
   return self
 end
 
---- Marker is readonly. Text cannot be changed and marker cannot be removed.
+--- Marker is read and write. Text cannot be changed and marker cannot be removed. The will not update the marker in the game, Call MARKER:Refresh to update state.
 -- @param #MARKER self
 -- @return #MARKER self
 function MARKER:ReadWrite()


### PR DESCRIPTION
Changes Marker.lua:

- ReadOnly and ReadWrite functions had the same description
- Completed missing remove function from class documentation

Changes MarkerOps_Base.lua

- Got confused myself on why event callbacks never reached me. Its because I was subscribed to MarkerAdded which always has a blank text. Wanted to make it easier for future users not to fall into that mistake
