### PR TITLE
Airwing sortpayloads criteria fix

### DIFF
--- a/Moose Development/Moose/Ops/AirWing.lua
+++ b/Moose Development/Moose/Ops/AirWing.lua
@@ -524,7 +524,7 @@ function AIRWING:FetchPayloadFromStock(UnitType, MissionType, Payloads)
     if a and b then  -- I had the case that a or b were nil even though the self.payloads table was looking okay. Very strange! Seems to be solved by pre-selecting valid payloads.
       local performanceA=self:GetPayloadPeformance(a, MissionType)
       local performanceB=self:GetPayloadPeformance(b, MissionType)
-      return (performanceA>performanceB) or (performanceA==performanceB and a.unlimited==true) or (performanceA==performanceB and a.unlimited==true and b.unlimited==true and a.navail>b.navail)
+      return (performanceA>performanceB) or (performanceA==performanceB and a.unlimited==true and b.unlimited~=true) or (performanceA==performanceB and a.unlimited==true and b.unlimited==true and a.navail>b.navail)
     elseif not a then
       self:I(self.lid..string.format("FF ERROR in sortpayloads: a is nil"))
       return false


### PR DESCRIPTION
The third condition in the sortpayloads() case where both A and B are not nil:

`(performanceA==performanceB and a.unlimited==true)`

only checks if `a.unlimited` is true and ignores the value of `b.unlimited`. This means that the fourth condition:

`(performanceA==performanceB and a.unlimited==true and b.unlimited==true and a.navail>b.navail)`

will never be used because by definition, if `performanceA==performanceB and a.unlimited==true` then the third condition already returned true, and the `b.unlimited==true and a.navail>b.navail` will not matter.


This was causing "invalid sort function" errors in my mission in the case where there are multiple unlimited payloads with equal performance for a given mission type.
