### PR TITLE
MSRS_BACKEND_DCSGRPC bug fix

### DIFF
--- a/Moose Development/Moose/Sound/SRS.lua
+++ b/Moose Development/Moose/Sound/SRS.lua
@@ -155,6 +155,18 @@
 --     -- Text-to speech with default voice after 30 seconds.
 --     msrs:PlaySoundText(text, 30)
 --
+-- Basic example of using another class (ATIS) with SRS and the DCS-gRPC backend (DCS-gRPC not previously started):
+--
+--     -- Start DCS-gRPC
+--     GRPC.load()
+--     -- Select the alternate DCS-gRPC backend for new MSRS instances
+--     MSRS.SetDefaultBackendGRPC()
+--     -- Create new ATIS as usual
+--     atis=ATIS:New("Nellis", 251, radio.modulation.AM)
+--     -- ATIS:SetSRS() expects a string for the SRS path even though it is not needed with DCS-gRPC
+--     atis:SetSRS('')
+--     -- Start ATIS
+--     atis:Start()
 --
 -- @field #MSRS
 MSRS = {

--- a/Moose Development/Moose/Sound/SRS.lua
+++ b/Moose Development/Moose/Sound/SRS.lua
@@ -1255,7 +1255,7 @@ MSRS_BACKEND_DCSGRPC.Functions._DCSgRPCtts = function (self, Text, Plaintext, Fr
     options.srsClientName = Label or self.Label
     options.position = {}
     if self.coordinate then
-        options.position.lat, options.position.lat, options.position.alt = self._GetLatLongAlt(self.coordinate)
+        options.position.lat, options.position.lat, options.position.alt = self:_GetLatLongAlt(self.coordinate)
     end
 
     options.position.lat = options.position.lat or 0.0


### PR DESCRIPTION
I found a bug I missed my previously merged DCS-gRPC plugin code.

"_DCSgRPCtts" function calling MSRS:_GetLatLongAlt() with a '.' instead of a ":", which resulted in an error when transmitting from a coordinate (because 'self' wasn't passed as the first perimeter as expected).