### PR TITLE
ZONE_UNIT:New() causes Offset data to be saved to every new ZONE_UNIT

### DIFF
--- a/Moose Development/Moose/Core/Zone.lua
+++ b/Moose Development/Moose/Core/Zone.lua
@@ -1616,15 +1616,17 @@ function ZONE_UNIT:New( ZoneName, ZoneUNIT, Radius, Offset)
     if (Offset.dx or Offset.dy) and (Offset.rho or Offset.theta) then
       error("Cannot use (dx, dy) with (rho, theta)")
     end
+  end
 
+  local self = BASE:Inherit( self, ZONE_RADIUS:New( ZoneName, ZoneUNIT:GetVec2(), Radius, true ) )
+
+  if Offset then
     self.dy = Offset.dy or 0.0
     self.dx = Offset.dx or 0.0
     self.rho = Offset.rho or 0.0
     self.theta = (Offset.theta or 0.0) * math.pi / 180.0
     self.relative_to_unit = Offset.relative_to_unit or false
   end
-
-  local self = BASE:Inherit( self, ZONE_RADIUS:New( ZoneName, ZoneUNIT:GetVec2(), Radius, true ) )
 
   self:F( { ZoneName, ZoneUNIT:GetVec2(), Radius } )
 


### PR DESCRIPTION
Since self.dy/self.dx/etc. are saved before `self` is reassigned via BASE:Inherit, this means that the values are saved to the ZONE_UNIT class itself and the `Offset` parameter values are therefore inherited by every ZONE_UNIT that is subsequently created.

Should be reordered so that data is only saved to `self` after self has been locally assigned to be a new ZONE_UNIT instance instead.

Just a note: I assumed that the validation of the `Offset` input and potential call to `error()` was intentionally explicitly performed before initializing the ZONE_UNIT object itself for a reason, and so I kept that behavior as is and only moved the value assignments to below the BASE:Inherit line.
