### PR TITLE
Set life0 based on itself, rather than off of life

### DIFF
--- a/Moose Development/Moose/Ops/OpsGroup.lua
+++ b/Moose Development/Moose/Ops/OpsGroup.lua
@@ -980,7 +980,7 @@ function OPSGROUP:GetLifePoints(Element)
     for _,element in pairs(self.elements) do
       local l,l0=self:GetLifePoints(element)
       life=life+l
-      life0=life+l0
+      life0=life0+l0
     end
 
   end


### PR DESCRIPTION
At the moment, the "life0" part of OPSGROUP:GetLifePoints is accidentally being set to the running total for life each iteration, rather than summing the values for life0.

This causes the "life0" value for an OPSGROUP to not make sense (and causes it to vary based on the _current_ life values of the group members, which definitely doesn't seem right)