### PR TITLE
Fix typo (Nmax -> Nmin) in CHIEF:RecruitAssetsForZone

### DIFF
--- a/Moose Development/Moose/Ops/Chief.lua
+++ b/Moose Development/Moose/Ops/Chief.lua
@@ -2969,7 +2969,7 @@ function CHIEF:RecruitAssetsForZone(StratZone, Resource)
   
   -- Shortcuts.
   local MissionType=Resource.MissionType
-  local NassetsMin=Resource.Nmax
+  local NassetsMin=Resource.Nmin
   local NassetsMax=Resource.Nmax
   local Categories=Resource.Categories
   local Attributes=Resource.Attributes


### PR DESCRIPTION
Setting `NassetsMin` to `Resource.Nmax` instead of `Resource.Nmin` causes Nmax assets to be required and assigned, even if a lower minimum count is specified on the resource.