### PR TITLE
Chief zone removal Tanker, AWACS

### DIFF
--- a/Moose Development/Moose/Ops/Chief.lua
+++ b/Moose Development/Moose/Ops/Chief.lua
@@ -1501,6 +1501,17 @@ function CHIEF:AddAwacsZone(Zone, Altitude, Speed, Heading, Leg)
   return zone
 end
 
+--- Remove a AWACS zone.
+-- @param #CHIEF self
+-- @param Core.Zone#ZONE Zone Zone, where the flight orbits.
+function CHIEF:RemoveAwacsZone(Zone)
+
+  -- Hand over to commander.
+  local zone=self.commander:RemoveAwacsZone(Zone)
+
+  return zone
+end
+
 --- Add a refuelling tanker zone.
 -- @param #CHIEF self
 -- @param Core.Zone#ZONE Zone Zone.
@@ -1518,6 +1529,16 @@ function CHIEF:AddTankerZone(Zone, Altitude, Speed, Heading, Leg, RefuelSystem)
   return zone
 end
 
+--- Remove a refuelling tanker zone.
+-- @param #CHIEF self
+-- @param Core.Zone#ZONE Zone Zone, where the flight orbits.
+function CHIEF:RemoveTankerZone(Zone)
+
+  -- Hand over to commander.
+  local zone=self.commander:RemoveTankerZone(Zone)
+
+  return zone
+end
 
 --- Set border zone set, defining your territory.
 -- 

--- a/Moose Development/Moose/Ops/Commander.lua
+++ b/Moose Development/Moose/Ops/Commander.lua
@@ -735,6 +735,26 @@ function COMMANDER:AddAwacsZone(Zone, Altitude, Speed, Heading, Leg)
   return awacszone
 end
 
+--- Remove a AWACS zone.
+-- @param #COMMANDER self
+-- @param Core.Zone#ZONE Zone Zone, where the flight orbits.
+function COMMANDER:RemoveAwacsZone(Zone)
+
+  local awacszone={} --Ops.AirWing#AIRWING.PatrolZone
+  
+  awacszone.zone=Zone
+  for i,_awacszone in pairs(self.awacsZones) do
+    if _awacszone.zone == awacszone.zone then
+      if _awacszone.mission and _awacszone.mission:IsNotOver() then
+          _awacszone.mission:Cancel()
+      end
+      table.remove(self.awacsZones, i)
+      break
+    end
+  end
+  return awacszone
+end
+
 --- Add a refuelling tanker zone.
 -- @param #COMMANDER self
 -- @param Core.Zone#ZONE Zone Zone.
@@ -759,6 +779,26 @@ function COMMANDER:AddTankerZone(Zone, Altitude, Speed, Heading, Leg, RefuelSyst
 
   table.insert(self.tankerZones, tankerzone)
 
+  return tankerzone
+end
+
+--- Remove a refuelling tanker zone.
+-- @param #COMMANDER self
+-- @param Core.Zone#ZONE Zone Zone, where the flight orbits.
+function COMMANDER:RemoveTankerZone(Zone)
+
+  local tankerzone={} --Ops.AirWing#AIRWING.PatrolZone
+  
+  tankerzone.zone=Zone
+  for i,_tankerzone in pairs(self.tankerZones) do
+    if _tankerzone.zone == tankerzone.zone then
+      if _tankerzone.mission and _tankerzone.mission:IsNotOver() then
+          _tankerzone.mission:Cancel()
+      end
+      table.remove(self.tankerZones, i)
+      break
+    end
+  end
   return tankerzone
 end
 


### PR DESCRIPTION
Add the ability to remove a zone for Tanker and AWACS, using Chief:RemoveTankerZone() and Chief:RemoveAwacsZone() .