### PR TITLE
Fix error in AUFTRAG:NewCAP when Altitude is not explicitly provided

### DIFF
--- a/Moose Development/Moose/Ops/Auftrag.lua
+++ b/Moose Development/Moose/Ops/Auftrag.lua
@@ -1312,8 +1312,11 @@ function AUFTRAG:NewCAP(ZoneCAP, Altitude, Speed, Coordinate, Heading, Leg, Targ
   -- Ensure given TargetTypes parameter is a table.
   TargetTypes=UTILS.EnsureTable(TargetTypes, true)
 
+  -- Set default altitude if not specified.
+  Altitude = Altitude or 10000
+
   -- Create ORBIT first.
-  local mission=AUFTRAG:NewORBIT(Coordinate or ZoneCAP:GetCoordinate(), Altitude or 10000, Speed or 350, Heading, Leg)
+  local mission=AUFTRAG:NewORBIT(Coordinate or ZoneCAP:GetCoordinate(), Altitude, Speed or 350, Heading, Leg)
 
   -- Mission type CAP.
   mission.type=AUFTRAG.Type.CAP


### PR DESCRIPTION
Ensure Altitude is not nil throughout AUFTRAG:NewCAP to avoid breaking the call to UTILS.KnotsToAltKIAS in:
`mission.missionSpeed = UTILS.KnotsToKmph(UTILS.KnotsToAltKIAS(Speed or 350, Altitude))`

It was already previously defaulted to 10000 when calling NewORBIT, but since the variable wasn't reassigned then the subsequent usages of Altitude caused errors.