### PR TITLE
Adding a new TerminalType (100) that seems to be introduced in the...

### DIFF
--- a/Moose Development/Moose/Wrapper/Airbase.lua
+++ b/Moose Development/Moose/Wrapper/Airbase.lua
@@ -760,11 +760,13 @@ AIRBASE.Sinai = {
 -- @field #number OpenMedOrBig 176: Combines OpenMed and OpenBig spots.
 -- @field #number HelicopterUsable 216: Combines HelicopterOnly, OpenMed and OpenBig.
 -- @field #number FighterAircraft 244: Combines Shelter. OpenMed and OpenBig spots. So effectively all spots usable by fixed wing aircraft.
+-- @field #number SmallSizeFigher 100: Tight spots for smaller type fixed wing aircraft, like the F-16. Example of these spots: 04, 05, 06 on Muwaffaq_Salti. A Viper sized plane can spawn here, but an A-10 or Strike Eagle can't
 AIRBASE.TerminalType = {
   Runway=16,
   HelicopterOnly=40,
   Shelter=68,
   OpenMed=72,
+  SmallSizeFighter=100,
   OpenBig=104,
   OpenMedOrBig=176,
   HelicopterUsable=216,
@@ -1841,7 +1843,7 @@ function AIRBASE._CheckTerminalType(Term_Type, termtype)
       match=true
      end
   elseif termtype==AIRBASE.TerminalType.FighterAircraft then
-    if Term_Type==AIRBASE.TerminalType.OpenMed or Term_Type==AIRBASE.TerminalType.OpenBig or Term_Type==AIRBASE.TerminalType.Shelter then
+    if Term_Type==AIRBASE.TerminalType.OpenMed or Term_Type==AIRBASE.TerminalType.OpenBig or Term_Type==AIRBASE.TerminalType.Shelter or Term_Type==AIRBASE.TerminalType.SmallSizeFighter then
       match=true
     end
   end


### PR DESCRIPTION
... update that brought Muwaffaq Salti. The base has a couple of spots (like 04, 05, 06) that can only accommodate smaller type fixed wing aircraft, like the F-16, but not bigger types like the Warthog of the Strike Eagle.

Because we weren't checking for this new type, spawning in these particular spots always resulted in an airstart, because `_CheckTerminalType` would always return `false`