### PR TITLE
Update Set.lua: added handler for EVENTS.PlayerLeaveUnit in SET_GROUP…

### DIFF
--- a/Moose Development/Moose/Core/Set.lua
+++ b/Moose Development/Moose/Core/Set.lua
@@ -1516,6 +1516,7 @@ do
       self:HandleEvent( EVENTS.Dead, self._EventOnDeadOrCrash )
       self:HandleEvent( EVENTS.Crash, self._EventOnDeadOrCrash )
       self:HandleEvent( EVENTS.RemoveUnit, self._EventOnDeadOrCrash )
+      self:HandleEvent( EVENTS.PlayerLeaveUnit, self._EventOnDeadOrCrash )
       if self.Filter.Zones then
         self.ZoneTimer = TIMER:New(self._ContinousZoneFilter,self)
         local timing = self.ZoneTimerInterval or 30


### PR DESCRIPTION
…:FilterStart() (#2134)

Ops.CSAR was throwing the following errors constantly when a player would leave the CSAR helo:

GROUP05000.GetDCSObject((ERROR: Could not get DCS group object of group Archer-1 because DCS object could not be found!))

This was because the SET_GROUP FilterStart on allheligroupset was not handling the scenario when a player left w/o a death.