### PR TITLE
Fix ZoneCaptureCoalition on player ejects / gets killed in zone

### DIFF
--- a/Moose Development/Moose/Core/Zone.lua
+++ b/Moose Development/Moose/Core/Zone.lua
@@ -1203,7 +1203,7 @@ function ZONE_RADIUS:GetScannedSetUnit()
         if FoundUnit then
           SetUnit:AddUnit( FoundUnit )
         else
-          local FoundStatic = STATIC:FindByName( UnitObject:getName() )
+          local FoundStatic = STATIC:FindByName( UnitObject:getName(), false )
           if FoundStatic then
             SetUnit:AddUnit( FoundStatic )
           end


### PR DESCRIPTION
ZoneCaptureCoalition.lua:879 calls GetScannedSetUnit and will stop the scheduler if the error message for STATICs is raised. We already have a check if it is present so we can add this explicitly here. Without the check the capture zone will not work anymore.


See this log entry for what happens when it isn't set:

```2024-07-20 21:58:11.772 INFO    SCRIPTING (Main): Error in timer function: [string "C:\Users\w3z315\Saved Games\DCS\Missions\Moose\Moose Development/Moose/Wrapper/Static.lua"]:117: STATIC not found for: Aerial-1-1
2024-07-20 21:58:11.772 INFO    SCRIPTING (Main): stack traceback:
	[string "C:\Users\w3z315\Saved Games\DCS\Missions\Moose\Moose Development/Moose/Core/ScheduleDispatcher.lua"]:180: in function <[string "C:\Users\w3z315\Saved Games\DCS\Missions\Moose\Moose Development/Moose/Core/ScheduleDispatcher.lua"]:177>
	[C]: in function 'error'
	[string "C:\Users\w3z315\Saved Games\DCS\Missions\Moose\Moose Development/Moose/Wrapper/Static.lua"]:117: in function 'FindByName'
	[string "C:\Users\w3z315\Saved Games\DCS\Missions\Moose\Moose Development/Moose/Core/Zone.lua"]:1207: in function 'GetScannedSetUnit'
	[string "C:\Users\w3z315\Saved Games\DCS\Missions\Moose\Moose Development/Moose/Functional/ZoneCaptureCoalition.lua"]:879: in function <[string "C:\Users\w3z315\Saved Games\DCS\Missions\Moose\Moose Development/Moose/Functional/ZoneCaptureCoalition.lua"]:843>
	(tail call): ?
	[C]: in function 'xpcall'
	[string "C:\Users\w3z315\Saved Games\DCS\Missions\Moose\Moose Development/Moose/Core/ScheduleDispatcher.lua"]:233: in function <[string "C:\Users\w3z315\Saved Games\DCS\Missions\Moose\Moose Development/Moose/Core/ScheduleDispatcher.lua"]:169>```