### PR TITLE
Update Base.lua

### DIFF
--- a/Moose Development/Moose/Core/Base.lua
+++ b/Moose Development/Moose/Core/Base.lua
@@ -26,7 +26,7 @@
 -- @module Core.Base
 -- @image Core_Base.JPG
 
-local _TraceOnOff = true
+local _TraceOnOff = false -- default to no tracing
 local _TraceLevel = 1
 local _TraceAll = false
 local _TraceClass = {}
@@ -1191,7 +1191,7 @@ end
 -- @param Arguments A #table or any field.
 function BASE:F( Arguments )
 
-  if BASE.Debug and _TraceOnOff then
+  if BASE.Debug and _TraceOnOff == true then
     local DebugInfoCurrent = BASE.Debug.getinfo( 2, "nl" )
     local DebugInfoFrom = BASE.Debug.getinfo( 3, "l" )
 
@@ -1206,7 +1206,7 @@ end
 -- @param Arguments A #table or any field.
 function BASE:F2( Arguments )
 
-  if BASE.Debug and _TraceOnOff then
+  if BASE.Debug and _TraceOnOff == true and _TraceLevel >= 2 then
     local DebugInfoCurrent = BASE.Debug.getinfo( 2, "nl" )
     local DebugInfoFrom = BASE.Debug.getinfo( 3, "l" )
 
@@ -1221,7 +1221,7 @@ end
 -- @param Arguments A #table or any field.
 function BASE:F3( Arguments )
 
-  if BASE.Debug and _TraceOnOff then
+  if BASE.Debug and _TraceOnOff == true and _TraceLevel >= 3 then
     local DebugInfoCurrent = BASE.Debug.getinfo( 2, "nl" )
     local DebugInfoFrom = BASE.Debug.getinfo( 3, "l" )
 
@@ -1265,7 +1265,7 @@ end
 -- @param Arguments A #table or any field.
 function BASE:T( Arguments )
 
-  if BASE.Debug and _TraceOnOff then
+  if BASE.Debug and _TraceOnOff == true then
     local DebugInfoCurrent = BASE.Debug.getinfo( 2, "nl" )
     local DebugInfoFrom = BASE.Debug.getinfo( 3, "l" )
 
@@ -1280,7 +1280,7 @@ end
 -- @param Arguments A #table or any field.
 function BASE:T2( Arguments )
 
-  if BASE.Debug and _TraceOnOff then
+  if BASE.Debug and _TraceOnOff == true and _TraceLevel >= 2 then
     local DebugInfoCurrent = BASE.Debug.getinfo( 2, "nl" )
     local DebugInfoFrom = BASE.Debug.getinfo( 3, "l" )
 
@@ -1295,7 +1295,7 @@ end
 -- @param Arguments A #table or any field.
 function BASE:T3( Arguments )
 
-  if BASE.Debug and _TraceOnOff then
+  if BASE.Debug and _TraceOnOff == true and _TraceLevel >= 3 then
     local DebugInfoCurrent = BASE.Debug.getinfo( 2, "nl" )
     local DebugInfoFrom = BASE.Debug.getinfo( 3, "l" )
 


### PR DESCRIPTION
Performance tuning - the BASE:I, F, T calls rank very high in overall number of calls taken from Moose. Ensure only the minimum number of actions based on trace state and level is taken