### PR TITLE
Update CSAR.lua - Updated correct type name for Kiowa to OH58D

### DIFF
--- a/Moose Development/Moose/Ops/CSAR.lua
+++ b/Moose Development/Moose/Ops/CSAR.lua
@@ -308,7 +308,7 @@ CSAR.AircraftType["AH-64D_BLK_II"] = 2
 CSAR.AircraftType["Bronco-OV-10A"] = 2
 CSAR.AircraftType["MH-60R"] = 10
 CSAR.AircraftType["OH-6A"] = 2
-CSAR.AircraftType["OH-58D"] = 2
+CSAR.AircraftType["OH58D"] = 2
 CSAR.AircraftType["CH-47Fbl1"] = 31
 
 --- CSAR class version.


### PR DESCRIPTION
Update CSAR.lua - Updated correct type name for Kiowa to OH58D - original Brykeller change