### PR TITLE
[FIXED] OpsZone never goes to `Attacked` state if `threatlevelCapture` is higher than 0.

### DIFF
--- a/Moose Development/Moose/Ops/OpsZone.lua
+++ b/Moose Development/Moose/Ops/OpsZone.lua
@@ -1314,7 +1314,7 @@ function OPSZONE:EvaluateZone()
       
       if Nblu>0 then
       
-        if not self:IsAttacked() and self.Tnut>=self.threatlevelCapture then
+        if not self:IsAttacked() and self.Tblu>=self.threatlevelCapture then
           self:Attacked(coalition.side.BLUE)
         end
         
@@ -1366,7 +1366,7 @@ function OPSZONE:EvaluateZone()
       
       if Nred>0 then
       
-        if not self:IsAttacked() and self.Tnut>=self.threatlevelCapture then
+        if not self:IsAttacked() and self.Tred>=self.threatlevelCapture then
           -- Red is attacking blue zone.
           self:Attacked(coalition.side.RED)
         end


### PR DESCRIPTION
It was calculating the threatlevel from Neutral coalition instead of the attacking coalition threat level.