### PR TITLE
[Fixed] Parameter #1 (unit name) is incorrect

### DIFF
--- a/Moose Development/Moose/Ops/OpsGroup.lua
+++ b/Moose Development/Moose/Ops/OpsGroup.lua
@@ -9045,7 +9045,7 @@ function OPSGROUP:AddWeightCargo(UnitName, Weight)
     self:T(self.lid..string.format("%s: Adding %.1f kg cargo weight. New cargo weight=%.1f kg", UnitName, Weight, element.weightCargo))
 
     -- For airborne units, we set the weight in game.
-    if self.isFlightgroup then
+    if self.isFlightgroup and element.name then
       trigger.action.setUnitInternalCargo(element.name, element.weightCargo)  --https://wiki.hoggitworld.com/view/DCS_func_setUnitInternalCargo
     end
 


### PR DESCRIPTION
```
2025-03-31 10:54:57.755 INFO    SCRIPTING (Main): Error in SCHEDULER function:[string "l10n/DEFAULT/Moose_.lua"]:103994: Parameter #1 (unit name) is incorrect
2025-03-31 10:54:57.755 INFO    SCRIPTING (Main): stack traceback:
	[string "l10n/DEFAULT/Moose_.lua"]:19100: in function <[string "l10n/DEFAULT/Moose_.lua"]:19097>
	[C]: in function 'setUnitInternalCargo'
	[string "l10n/DEFAULT/Moose_.lua"]:103994: in function 'AddWeightCargo'
	[string "l10n/DEFAULT/Moose_.lua"]:104000: in function 'RedWeightCargo'
	[string "l10n/DEFAULT/Moose_.lua"]:103791: in function '_DelCargobay'
	[string "l10n/DEFAULT/Moose_.lua"]:103243: in function 'onafterElementDead'
	[string "l10n/DEFAULT/Moose_.lua"]:93853: in function <[string "l10n/DEFAULT/Moose_.lua"]:93849>
	(tail call): ?
	[C]: in function 'xpcall'
	[string "l10n/DEFAULT/Moose_.lua"]:19104: in function '_call_handler'
	[string "l10n/DEFAULT/Moose_.lua"]:19182: in function <[string "l10n/DEFAULT/Moose_.lua"]:19110>
	...
	(tail call): ?
	[string "l10n/DEFAULT/Moose_.lua"]:103196: in function <[string "l10n/DEFAULT/Moose_.lua"]:103184>
	(tail call): ?
	[C]: in function 'xpcall'
	[string "l10n/DEFAULT/Moose_.lua"]:19104: in function '_call_handler'
	[string "l10n/DEFAULT/Moose_.lua"]:19182: in function <[string "l10n/DEFAULT/Moose_.lua"]:19110>
	(tail call): ?
	[string "l10n/DEFAULT/Moose_.lua"]:104968: in function '_CheckDamage'
	[string "l10n/DEFAULT/Moose_.lua"]:93543: in function 'func'
	[string "l10n/DEFAULT/Moose_.lua"]:21688: in function <[string "l10n/DEFAULT/Moose_.lua"]:21687>
```