### PR TITLE
Update Set.lua

### DIFF
--- a/Moose Development/Moose/Core/Set.lua
+++ b/Moose Development/Moose/Core/Set.lua
@@ -8755,7 +8755,6 @@ do -- SET_DYNAMICCARGO
   -- @field #SET_DYNAMICCARGO SET_DYNAMICCARGO
   SET_DYNAMICCARGO = {
     ClassName = "SET_DYNAMICCARGO",
-    Filter = {},
     Set = {},
     List = {},
     Index = {},


### PR DESCRIPTION
Removed the Filter={},

This is how it was before:
SET_DYNAMICCARGO={
ClassName="SET_DYNAMICCARGO",
Filter={},
Set={},
List={},
Index={},
Database=nil,
CallScheduler=nil,
Filter={
Coalitions=nil,
Types=nil,
Countries=nil,
StaticPrefixes=nil,
Zones=nil,
},