### PR TITLE
[FIXED] Memory leaks

### DIFF
--- a/Moose Development/Moose/Core/MarkerOps_Base.lua
+++ b/Moose Development/Moose/Core/MarkerOps_Base.lua
@@ -156,12 +156,6 @@ function MARKEROPS_BASE:OnEventMark(Event)
     end
     --position
     local vec3={y=Event.pos.y, x=Event.pos.x, z=Event.pos.z}
-    local coord=COORDINATE:NewFromVec3(vec3)
-    if self.debug then
-      local coordtext = coord:ToStringLLDDM()
-      local text = tostring(Event.text)
-      local m = MESSAGE:New(string.format("Mark added at %s with text: %s",coordtext,text),10,"Info",false):ToAll()
-    end
     local coalition = Event.MarkCoalition
     -- decision
     if Event.id==world.event.S_EVENT_MARK_ADDED then
@@ -170,6 +164,12 @@ function MARKEROPS_BASE:OnEventMark(Event)
       local Eventtext = tostring(Event.text)
       if Eventtext~=nil then
         if self:_MatchTag(Eventtext) then
+            local coord=COORDINATE:NewFromVec3(vec3)
+            if self.debug then
+              local coordtext = coord:ToStringLLDDM()
+              local text = tostring(Event.text)
+              local m = MESSAGE:New(string.format("Mark added at %s with text: %s",coordtext,text),10,"Info",false):ToAll()
+            end
          local matchtable = self:_MatchKeywords(Eventtext)
          self:MarkAdded(Eventtext,matchtable,coord,Event.idx,coalition,Event.PlayerName,Event)
         end
@@ -180,6 +180,12 @@ function MARKEROPS_BASE:OnEventMark(Event)
       local Eventtext = tostring(Event.text)
       if Eventtext~=nil then
         if self:_MatchTag(Eventtext) then
+            local coord=COORDINATE:NewFromVec3(vec3)
+            if self.debug then
+              local coordtext = coord:ToStringLLDDM()
+              local text = tostring(Event.text)
+              local m = MESSAGE:New(string.format("Mark added at %s with text: %s",coordtext,text),10,"Info",false):ToAll()
+            end
          local matchtable = self:_MatchKeywords(Eventtext)
          self:MarkChanged(Eventtext,matchtable,coord,Event.idx,coalition,Event.PlayerName,Event)
         end

--- a/Moose Development/Moose/Core/Zone.lua
+++ b/Moose Development/Moose/Core/Zone.lua
@@ -3204,12 +3204,7 @@ function ZONE_POLYGON:Scan( ObjectCategories, UnitCategories )
 
   local vectors = self:GetBoundingSquare()
 
-  local minVec3 = {x=vectors.x1, y=0, z=vectors.y1}
-  local maxVec3 = {x=vectors.x2, y=0, z=vectors.y2}
-
-  local minmarkcoord = COORDINATE:NewFromVec3(minVec3)
-  local maxmarkcoord = COORDINATE:NewFromVec3(maxVec3)
-  local ZoneRadius = minmarkcoord:Get2DDistance(maxmarkcoord)/2
+  local ZoneRadius = UTILS.VecDist2D({x=vectors.x1, y=vectors.y1}, {x=vectors.x2, y=vectors.y2})/2
 --  self:I("Scan Radius:" ..ZoneRadius)
   local CenterVec3 = self:GetCoordinate():GetVec3()
 

--- a/Moose Development/Moose/Functional/Warehouse.lua
+++ b/Moose Development/Moose/Functional/Warehouse.lua
@@ -6893,7 +6893,7 @@ function WAREHOUSE:_CheckConquered()
     for _,_unit in pairs(units) do
       local unit=_unit --Wrapper.Unit#UNIT
 
-      local distance=coord:Get2DDistance(unit:GetCoordinate())
+      local distance=coord:Get2DDistance(unit:GetCoord())
 
       -- Filter only alive groud units. Also check distance again, because the scan routine might give some larger distances.
       if unit:IsGround() and unit:IsAlive() and distance <= radius then


### PR DESCRIPTION
- We have 8x `MARKEROPS_BASE` implemented, every time ATIS updates mark points the Mark event is triggered for each ATIS instance, we also have over 400 zones, drawing CircleToAll as well as TextToAll every few minutes which also trigger the Mark event, as well as all other scripts we have creating/changing/deleting marks, this sums up to thousands of COORDINATE objects created in the span of few minutes that are not needed because the Tag doesn't match.

- `ZONE_POLYGON:Scan` triggered a lot during our mission cycle, it's creating 2x `COORDINATE` objects only to calculate the distance between them, therefore it's more efficient to use `UTILS.VecDist2D` instead.

- `WAREHOUSE:_CheckConquered()` Triggered constantly in our mission, for multiple instances, `unit:GetCoordinate()` is unnecessary, changed to `unit:GetCoord()`


I added a `debug.traceback()` to `BASE:Inherit` to log every single object in MOOSE that is being created and was able to find a lot of objects that are being created unnecessarily, these are the main ones. After testing these changes we were able to cut back a lot on memory usage and therefore less GC work which in turn got rid of the hickups and ultimately desync, not to mention, we saw a 30% CPU usage improvement.  More to follow.