### PR TITLE
[FIXED] AUFTRAG and FSM state mismatch workaround `AUFTRAG:CheckGroupsDone`

### DIFF
--- a/Moose Development/Moose/Ops/Auftrag.lua
+++ b/Moose Development/Moose/Ops/Auftrag.lua
@@ -4801,6 +4801,8 @@ end
 -- @return #boolean If `true`, all groups are done with the mission.
 function AUFTRAG:CheckGroupsDone()
 
+  local fsmState = self:GetState()
+
   -- Check status of all OPS groups.
   for groupname,data in pairs(self.groupdata) do
     local groupdata=data --#AUFTRAG.GroupData
@@ -4859,7 +4861,7 @@ function AUFTRAG:CheckGroupsDone()
     return true
   end
   
-  if (self:IsStarted() or self:IsExecuting()) and self:CountOpsGroups()>0 then
+  if (self:IsStarted() or self:IsExecuting()) and (fsmState == AUFTRAG.Status.STARTED or fsmState == AUFTRAG.Status.EXECUTING) and self:CountOpsGroups()>0 then
     self:T(self.lid..string.format("CheckGroupsDone: Mission is STARTED state %s [FSM=%s] and count of alive OPSGROUP > zero. Mission NOT DONE!", self.status, self:GetState()))
     return false
   end


### PR DESCRIPTION
This is a workaround. It seems that  AUFTRAG and FSM states are not in sync, needs further testing and troubleshoot.