### PR TITLE
TeTeT/develop - Vietnam War Vessels support in Airboss

### DIFF
--- a/Moose Development/Moose/Ops/Airboss.lua
+++ b/Moose Development/Moose/Ops/Airboss.lua
@@ -1317,6 +1317,10 @@ AIRBOSS.AircraftCarrier={
 -- @field #string FORRESTAL USS Forrestal (CV-59) [Heatblur Carrier Module]
 -- @field #string VINSON USS Carl Vinson (CVN-70) [Deprecated!]
 -- @field #string ESSEX Essex class carrier (e.g. USS Yorktown (CV-10)) [Magnitude 3 Carrier Module]
+-- @field #string BONHOMMERICHARD USS Bon Homme Richard carrier [VWV Mod]
+-- @field #string ESSEXSCB125 Generic Essex class carrier with angled deck (SCB-125 upgrade) [VWV Mod]
+-- @field #string ENTERPRISE66 USS Enterprise in the 1966 configuration [VWV Mod]
+-- @field #string ENTERPRISEMODERN USS Enterprise in a modern configuration [Derived VWV Mod]
 -- @field #string HERMES HMS Hermes (R12) [V/STOL Carrier]
 -- @field #string INVINCIBLE HMS Invincible (R05) [V/STOL Carrier]
 -- @field #string TARAWA USS Tarawa (LHA-1) [V/STOL Carrier]
@@ -1331,8 +1335,12 @@ AIRBOSS.CarrierType = {
   TRUMAN = "CVN_75",
   STENNIS = "Stennis",
   FORRESTAL = "Forrestal",
+  ENTERPRISE66 = "USS Enterprise 1966",
+  ENTERPRISEMODERN = "cvn-65",
   VINSON = "VINSON",
   ESSEX = "Essex",
+  BONHOMMERICHARD = "USS Bon Homme Richard",
+  ESSEXSCB125 = "essex_scb125",
   HERMES = "HERMES81",
   INVINCIBLE = "hms_invincible",
   TARAWA = "LHA_Tarawa",
@@ -2019,11 +2027,19 @@ function AIRBOSS:New( carriername, alias )
     self:_InitNimitz()
   elseif self.carriertype == AIRBOSS.CarrierType.FORRESTAL then
     self:_InitForrestal()
+  elseif self.carriertype == AIRBOSS.CarrierType.ENTERPRISE66 then
+    self:_InitEnterprise()
+  elseif self.carriertype == AIRBOSS.CarrierType.ENTERPRISEMODERN then
+    self:_InitEnterprise()
   elseif self.carriertype == AIRBOSS.CarrierType.VINSON then
     -- Carl Vinson is legacy now.
     self:_InitStennis()
   elseif self.carriertype == AIRBOSS.CarrierType.ESSEX then
     self:_InitEssex()
+  elseif self.carriertype == AIRBOSS.CarrierType.BONHOMMERICHARD then
+    self:_InitBonHommeRichard()
+  elseif self.carriertype == AIRBOSS.CarrierType.ESSEXSCB125 then
+    self:_InitEssexSCB125()
   elseif self.carriertype == AIRBOSS.CarrierType.HERMES then
     -- Hermes parameters.
     self:_InitHermes()
@@ -4653,6 +4669,26 @@ function AIRBOSS:_InitForrestal()
 
 end
 
+--- Init parameters for Enterprise carrier.
+-- @param #AIRBOSS self
+function AIRBOSS:_InitEnterprise()
+  -- Using Forrestal as template
+  self:_InitForrestal()
+
+  self.carrierparam.sterndist = -164.30
+  self.carrierparam.deckheight = 19.52
+
+  self.carrierparam.totlength = 335
+  self.carrierparam.rwylength = 223
+
+  -- Wires.
+  self.carrierparam.wire1 = 57.7
+  self.carrierparam.wire2 = 69.6
+  self.carrierparam.wire3 = 79.5
+  self.carrierparam.wire4 = 90.0
+
+end
+
 --- Init parameters for Essec class carriers.
 -- @param #AIRBOSS self
 function AIRBOSS:_InitEssex()
@@ -4695,6 +4731,35 @@ function AIRBOSS:_InitEssex()
 
   -- Landing distance.
   self.carrierparam.landingdist = self.carrierparam.sterndist+self.carrierparam.wire3
+
+end
+
+--- Init parameters for CVA-31 Bon Homme Richard carriers.
+-- @param #AIRBOSS self
+function AIRBOSS:_InitBonHommeRichard()
+  -- Init Essex as default
+  self:_InitEssex()
+
+  self.carrierparam.deckheight = 16.95
+
+  -- Landing runway.
+  -- from BHR EssexRunwayAndRoutes.lua
+  self.carrierparam.rwyangle = -11.4
+  self.carrierparam.rwylength = 97
+  self.carrierparam.rwywidth = 20
+
+  -- Wires.
+  self.carrierparam.wire1 = 40.4 -- Distance from stern to first wire. Original from Frank - 42
+  self.carrierparam.wire2 = 45
+  self.carrierparam.wire3 = 51
+  self.carrierparam.wire4 = 58.1
+end
+
+--- Init parameters for Generic Essex SC125 class carriers.
+-- @param #AIRBOSS self
+function AIRBOSS:_InitEssexSCB125()
+  -- Init Bon Homme Richard as default
+  self:_InitBonHommeRichard()
 
 end
 


### PR DESCRIPTION
Add support for Vietnam War Vessels carriers to Airboss:
    - CVA-31 Bon Homme Richard
    - Generic Essex with SCB-125 upgrade (angled Deck)
    - CVAN-65 Enterprise 1966
    - CVN-65 Enterprise modern

The mod is available from https://github.com/tspindler-cms/tetet-vwv/releases 