### PR TITLE
[ADDED] `GROUP:GetBoundingBox()` 

### DIFF
--- a/Moose Development/Moose/Wrapper/Group.lua
+++ b/Moose Development/Moose/Wrapper/Group.lua
@@ -3207,3 +3207,49 @@ end
 function GROUP:SetValidateAndRepositionGroundUnits(Enabled)
     self.ValidateAndRepositionGroundUnits = Enabled
 end
+
+
+--- Get the bounding box of the group combining UNIT:GetBoundingBox() units.
+-- @param #GROUP self
+-- @return DCS#Box3 The bounding box of the GROUP.
+-- @return #nil The GROUP does not have any alive units.
+function GROUP:GetBoundingBox()
+    local bbox = { min = { x = math.huge, y = math.huge, z = math.huge },
+                   max = { x = -math.huge, y = -math.huge, z = -math.huge }
+    }
+
+    local Units = self:GetUnits() or {}
+    if #Units == 0 then
+        return nil
+    end
+
+    for _, unit in pairs(Units) do
+        if unit and unit:IsAlive() then
+            local ubox = unit:GetBoundingBox()
+
+            if ubox then
+                if ubox.min.x < bbox.min.x then
+                    bbox.min.x = ubox.min.x
+                end
+                if ubox.min.y < bbox.min.y then
+                    bbox.min.y = ubox.min.y
+                end
+                if ubox.min.z < bbox.min.z then
+                    bbox.min.z = ubox.min.z
+                end
+
+                if ubox.max.x > bbox.max.x then
+                    bbox.max.x = ubox.max.x
+                end
+                if ubox.max.y > bbox.max.y then
+                    bbox.max.y = ubox.max.y
+                end
+                if ubox.max.z > bbox.max.z then
+                    bbox.max.z = ubox.max.z
+                end
+            end
+        end
+    end
+
+    return bbox
+end


### PR DESCRIPTION
`POSITIONABLE:GetBoundingBox()` is only for units and produces errors when calling it from a `GROUP`.