### PR TITLE
[FIXED] Incorrect Airbase center position. [ADDED] UH-60L weapons

### DIFF
--- a/Moose Development/Moose/Utilities/Enums.lua
+++ b/Moose Development/Moose/Utilities/Enums.lua
@@ -606,7 +606,7 @@ ENUMS.Storage = {
     OH58 = {}, -- Kiowa specifics
     UH1H = {}, -- Huey specifics
     AH64D = {}, -- Huey specifics
-    UH60L = {}, -- Huey specifics
+    UH60L = {}, -- Blackhawk specifics
   }
 }
 

--- a/Moose Development/Moose/Utilities/Enums.lua
+++ b/Moose Development/Moose/Utilities/Enums.lua
@@ -606,6 +606,7 @@ ENUMS.Storage = {
     OH58 = {}, -- Kiowa specifics
     UH1H = {}, -- Huey specifics
     AH64D = {}, -- Huey specifics
+    UH60L = {}, -- Huey specifics
   }
 }
 
@@ -1315,6 +1316,15 @@ ENUMS.Storage.weapons.UH1H.M134_MiniGun_Right_Door  =  {4,15,46,175}
 ENUMS.Storage.weapons.UH1H.M60_MG_Right_Door  =  {4,15,46,177}
 ENUMS.Storage.weapons.UH1H.M134_MiniGun_Left_Door  =  {4,15,46,174}
 ENUMS.Storage.weapons.UH1H.M60_MG_Left_Door  =  {4,15,46,176}
+-- UH-60L
+ENUMS.Storage.weapons.UH60L.M151_HYDRA = {4, 7, 33, 147} -- 2.75" Hydra, UnGd Rkts M151, HE
+ENUMS.Storage.weapons.UH60L.M156_HYDRA = {4, 7, 33, 148} -- 2.75" Hydra, UnGd Rkts M156, Wht Phos
+ENUMS.Storage.weapons.UH60L.M229_HYDRA = {4, 7, 33, 148} -- 2.75" Hydra, UnGd Rkts M229, HE
+ENUMS.Storage.weapons.UH60L.M257_HYDRA = {4, 7, 33, 151} -- 2.75" Hydra, UnGd Rkts M257, Para Illum
+ENUMS.Storage.weapons.UH60L.M259_HYDRA = {4, 7, 33, 151} -- 2.75" Hydra, UnGd Rkts M259, Smoke Marker
+ENUMS.Storage.weapons.UH60L.M274_HYDRA = {4, 7, 33, 150} -- 2.75" Hydra, UnGd Rkts M274, Practice Smk
+
+
 -- Kiowa
 ENUMS.Storage.weapons.OH58.FIM92  =  {4,4,7,449}
 ENUMS.Storage.weapons.OH58.MG_M3P100  =  {4,15,46,2611}

--- a/Moose Development/Moose/Wrapper/Airbase.lua
+++ b/Moose Development/Moose/Wrapper/Airbase.lua
@@ -1574,6 +1574,17 @@ end
   return self
 end
 
+
+--- Get the true airbase center as seen in the ME. The position returned by the dcs object is is wrong and often at the start of the runway.
+-- @return DCS#Vec2 The center of the true center of the airbase if it contains runways, otherwise the default DCS object position.
+function AIRBASE:GetVec2()
+    local runways = self:GetRunways()
+    if runways and #runways > 0 then
+        return runways[1].center:GetVec2()
+    end
+    return self:GetCoordinate():GetVec2()
+end
+
 --- Get the category of this airbase. This is only a debug function because DCS 2.9 incorrectly returns heliports as airdromes.
 -- @param #AIRBASE self
 function AIRBASE:_GetCategory()


### PR DESCRIPTION
[FIXED] Incorrect Airbase center position.
Airbase DCS object returns the wrong position (point at the start of the runway), this causes airbase zones to be offset and inconsistent with the ME airbase zones and airbase label (map label is the center) which in turn causes the zone to not cover the whole airbase

[ADDED] UH-60L weapons