### PR TITLE
Add RAT prediction for destination ship location

### DIFF
--- a/Moose Development/Moose/Functional/RAT.lua
+++ b/Moose Development/Moose/Functional/RAT.lua
@@ -3042,6 +3042,14 @@ function RAT:_SetRoute(takeoff, landing, _departure, _destination, _waypoint)
   if landing==RAT.wp.air then
     local vec2=destination:GetRandomVec2()
     Pdestination=COORDINATE:NewFromVec2(vec2)
+  elseif destination:IsShip() then
+    -- Crudely predict where the ship will be
+    local _ship = UNIT:FindByName(destination:GetName())
+    local _shipHeading = _ship:GetHeading()
+    Pdestination=destination:GetCoordinate()
+    local _transitTime = Pdeparture:Get2DDistance(Pdestination) / VxCruise
+    Pdestination.x = Pdestination.x + (_ship:GetGroundSpeed() * math.cos(math.rad(_shipHeading)) * _transitTime)
+    Pdestination.z = Pdestination.z + (_ship:GetGroundSpeed() * math.sin(math.rad(_shipHeading)) * _transitTime)
   else
     Pdestination=destination:GetCoordinate()
   end


### PR DESCRIPTION
Currently, RAT routes aircraft to where the destination is at spawn time.

This is inefficient if the destination airfield moves, like it does for aircraft carriers/ships.

This adds a crude position prediction function so aircraft with long transit times (e.g., helicopters) don't wind up descending ~15 nmi behind the boat, then having to fly another 15-20 nmi leg just to get to the destination.