### PR TITLE
Fix SpawnAtAirbase emergency airspawn ground-flag bug

### DIFF
--- a/Moose Development/Moose/Core/Spawn.lua
+++ b/Moose Development/Moose/Core/Spawn.lua
@@ -2285,6 +2285,7 @@ function SPAWN:SpawnAtAirbase( SpawnAirbase, Takeoff, TakeoffAltitude, TerminalT
             end
 
             Takeoff = GROUP.Takeoff.Air
+            spawnonground = false
           else
             self:E( string.format( "WARNING: Group %s has no parking spots at %s ==> No emergency air start or uncontrolled spawning ==> No spawn!", self.SpawnTemplatePrefix, SpawnAirbase:GetName() ) )
             return nil


### PR DESCRIPTION
When no parking is available, SpawnAtAirbase switches to air start (Takeoff=Air) but spawnonground remained true. This caused nil indexing of parkingspots during unit placement. Set spawnonground=false when emergency airspawn is selected to keep placement on the airspawn path.