### PR TITLE
Update Spawn.lua

### DIFF
--- a/Moose Development/Moose/Core/Spawn.lua
+++ b/Moose Development/Moose/Core/Spawn.lua
@@ -2178,15 +2178,43 @@ function SPAWN:SpawnAtAirbase( SpawnAirbase, Takeoff, TakeoffAltitude, TerminalT
         local scanscenery = false
         local verysafe = false
 
+        -- Use exact parking data when provided, otherwise let helicopters on ships/FARPs
+        -- use the smarter parking search before falling back to the procedural queue path.
+        local useexplicitspots = false
+
         -- Number of free parking spots at the airbase.
-        if autoparking then
+        if Parkingdata~=nil then
+          -- Parking data explicitly set by user as input parameter.
+          nfree = #Parkingdata
+          spots = Parkingdata
+          useexplicitspots = true
+        elseif autoparking and AirbaseCategory == Airbase.Category.HELIPAD and ishelo then
+          if termtype == nil then
+            -- Helo is spawned. Try exclusive helo spots first.
+            spots = SpawnAirbase:FindFreeParkingSpotForAircraft( group, AIRBASE.TerminalType.HelicopterOnly, scanradius, scanunits, scanstatics, scanscenery, verysafe, nunits, nil )
+            nfree = #spots
+            if nfree < nunits then
+              -- Not enough helo ports. Let's try also other terminal types.
+              spots = SpawnAirbase:FindFreeParkingSpotForAircraft( group, AIRBASE.TerminalType.HelicopterUsable, scanradius, scanunits, scanstatics, scanscenery, verysafe, nunits, nil )
+              nfree = #spots
+            end
+          else
+            -- Terminal type explicitly given.
+            spots = SpawnAirbase:FindFreeParkingSpotForAircraft( group, termtype, scanradius, scanunits, scanstatics, scanscenery, verysafe, nunits, nil )
+            nfree = #spots
+          end
+
+          if nfree >= nunits then
+            useexplicitspots = true
+          else
+            -- These places work procedural and have some kind of build in queue ==> Less effort.
+            nfree = SpawnAirbase:GetFreeParkingSpotsNumber( termtype, true )
+            spots = SpawnAirbase:GetFreeParkingSpotsTable( termtype, true )
+          end
+        elseif autoparking then
           -- These places work procedural and have some kind of build in queue ==> Less effort.
           nfree = SpawnAirbase:GetFreeParkingSpotsNumber( termtype, true )
           spots = SpawnAirbase:GetFreeParkingSpotsTable( termtype, true )
-        elseif Parkingdata~=nil then
-          -- Parking data explicitly set by user as input parameter. (This was commented out for some unknown reason. But I need it this way.)
-          nfree=#Parkingdata
-          spots=Parkingdata
         else
           if ishelo then
             if termtype == nil then
@@ -2238,7 +2266,7 @@ function SPAWN:SpawnAtAirbase( SpawnAirbase, Takeoff, TakeoffAltitude, TerminalT
         local _notenough = false
 
         -- Need to differentiate some cases again.
-        if autoparking then
+        if autoparking and not useexplicitspots then
 
           -- On free spot required in these cases.
           if nfree >= 1 then
@@ -2582,21 +2610,51 @@ function SPAWN:ParkAircraft( SpawnAirbase, TerminalType, Parkingdata, SpawnIndex
       local scanscenery = false
       local verysafe = false
 
-      -- Number of free parking spots at the airbase.
-      if spawnonship or spawnonfarp or spawnonrunway then
-        -- These places work procedural and have some kind of build in queue ==> Less effort.
-        --self:T2( string.format( "Group %s is spawned on farp/ship/runway %s.", self.SpawnTemplatePrefix, SpawnAirbase:GetName() ) )
-        nfree = SpawnAirbase:GetFreeParkingSpotsNumber( termtype, true )
-        spots = SpawnAirbase:GetFreeParkingSpotsTable( termtype, true )
-        --[[
-      elseif Parkingdata~=nil then
-        -- Parking data explicitly set by user as input parameter.
-        nfree=#Parkingdata
-        spots=Parkingdata
-      ]]
-      else
-        if ishelo then
+        -- Use exact parking data when provided, otherwise let helicopters on FARPs
+        -- use the smarter parking search before falling back to the procedural queue path.
+        local useexplicitspots = false
+
+        -- Number of free parking spots at the airbase.
+        if Parkingdata~=nil then
+          -- Parking data explicitly set by user as input parameter.
+          nfree = #Parkingdata
+          spots = Parkingdata
+          useexplicitspots = true
+        elseif spawnonfarp and ishelo then
           if termtype == nil then
+            -- Helo is spawned. Try exclusive helo spots first.
+            --self:T2( string.format( "Helo group %s is at %s using terminal type %d.", self.SpawnTemplatePrefix, SpawnAirbase:GetName(), AIRBASE.TerminalType.HelicopterOnly ) )
+            spots = SpawnAirbase:FindFreeParkingSpotForAircraft( TemplateGroup, AIRBASE.TerminalType.HelicopterOnly, scanradius, scanunits, scanstatics, scanscenery, verysafe, nunits, nil )
+            nfree = #spots
+            if nfree < nunits then
+              -- Not enough helo ports. Let's try also other terminal types.
+              --self:T2( string.format( "Helo group %s is at %s using terminal type %d.", self.SpawnTemplatePrefix, SpawnAirbase:GetName(), AIRBASE.TerminalType.HelicopterUsable ) )
+              spots = SpawnAirbase:FindFreeParkingSpotForAircraft( TemplateGroup, AIRBASE.TerminalType.HelicopterUsable, scanradius, scanunits, scanstatics, scanscenery, verysafe, nunits, nil )
+              nfree = #spots
+            end
+          else
+            -- Terminal type explicitly given.
+            --self:T2( string.format( "Helo group %s is at %s using terminal type %d.", self.SpawnTemplatePrefix, SpawnAirbase:GetName(), termtype ) )
+            spots = SpawnAirbase:FindFreeParkingSpotForAircraft( TemplateGroup, termtype, scanradius, scanunits, scanstatics, scanscenery, verysafe, nunits, nil )
+            nfree = #spots
+          end
+
+          if nfree >= nunits then
+            useexplicitspots = true
+          else
+            -- These places work procedural and have some kind of build in queue ==> Less effort.
+            --self:T2( string.format( "Group %s is spawned on farp %s using procedural spots.", self.SpawnTemplatePrefix, SpawnAirbase:GetName() ) )
+            nfree = SpawnAirbase:GetFreeParkingSpotsNumber( termtype, true )
+            spots = SpawnAirbase:GetFreeParkingSpotsTable( termtype, true )
+          end
+        elseif spawnonship or spawnonfarp or spawnonrunway then
+          -- These places work procedural and have some kind of build in queue ==> Less effort.
+          --self:T2( string.format( "Group %s is spawned on farp/ship/runway %s.", self.SpawnTemplatePrefix, SpawnAirbase:GetName() ) )
+          nfree = SpawnAirbase:GetFreeParkingSpotsNumber( termtype, true )
+          spots = SpawnAirbase:GetFreeParkingSpotsTable( termtype, true )
+        else
+          if ishelo then
+            if termtype == nil then
             -- Helo is spawned. Try exclusive helo spots first.
             --self:T2( string.format( "Helo group %s is at %s using terminal type %d.", self.SpawnTemplatePrefix, SpawnAirbase:GetName(), AIRBASE.TerminalType.HelicopterOnly ) )
             spots = SpawnAirbase:FindFreeParkingSpotForAircraft( TemplateGroup, AIRBASE.TerminalType.HelicopterOnly, scanradius, scanunits, scanstatics, scanscenery, verysafe, nunits, Parkingdata )
@@ -2659,7 +2717,7 @@ function SPAWN:ParkAircraft( SpawnAirbase, TerminalType, Parkingdata, SpawnIndex
       local _notenough = false
 
       -- Need to differentiate some cases again.
-      if spawnonship or spawnonfarp or spawnonrunway then
+      if (spawnonship or spawnonfarp or spawnonrunway) and not useexplicitspots then
 
         -- On free spot required in these cases. 
         if nfree >= 1 then

--- a/Moose Development/Moose/Ops/CSAR.lua
+++ b/Moose Development/Moose/Ops/CSAR.lua
@@ -504,6 +504,9 @@ CSAR.AircraftType["OH58D"] = 2
 CSAR.AircraftType["CH-47Fbl1"] = 31
 CSAR.AircraftType["AH-6J"] = 2
 CSAR.AircraftType["MH-6J"] = 2
+CSAR.AircraftType["Ka-50_3"] = 0
+CSAR.AircraftType["Ka-50"] = 0
+CSAR.AircraftType["AV8BNA"] = 0
 
 --- CSAR class version.
 -- @field #string version
@@ -2538,8 +2541,11 @@ function CSAR:_AddMedevacMenuItem()
     if _unit then
       --self:T("Unitname ".._unit:GetName().." IsAlive "..tostring(_unit:IsAlive()).." IsPlayer "..tostring(_unit:IsPlayer()))
       if _unit:IsAlive() and _unit:IsPlayer() then
-        local unitName = _unit:GetName()
-        _UnitList[unitName] = unitName
+        local _maxUnits = self.AircraftType[_unit:GetTypeName()]
+        if _maxUnits == nil or _maxUnits > 0 then
+          local unitName = _unit:GetName()
+          _UnitList[unitName] = unitName
+        end
       end -- end isAlive
     end -- end if _unit
   end -- end for


### PR DESCRIPTION
SPAWN:SpawnAtAirbase() and SPAWN:ParkAircraft() now handle HELIPAD/FARP parking the same way as airbases: explicit parking is honored first, helicopter spawns try the smarter parking search before falling back to the simpler free-spot table.

CSAR:

CSAR now treats aircraft with AircraftType[type] <= 0 as not CSAR-capable when building the active SAR unit list, while still allowing those type keys to exist for other systems such as FARP warehouse.

Added:

CSAR.AircraftType["Ka-50_3"] = 0
CSAR.AircraftType["Ka-50"] = 0
CSAR.AircraftType["AV8BNA"] = 0