### PR TITLE
fix(Spawn): air-spawn takeoff event never fired (wrong arg packing)

### DIFF
--- a/Moose Development/Moose/Core/Spawn.lua
+++ b/Moose Development/Moose/Core/Spawn.lua
@@ -2430,8 +2430,13 @@ function SPAWN:SpawnAtAirbase( SpawnAirbase, Takeoff, TakeoffAltitude, TerminalT
       -- When spawned in the air, we need to generate a Takeoff Event.
       if Takeoff == GROUP.Takeoff.Air then
         for UnitID, UnitSpawned in pairs( GroupSpawned:GetUnits() ) do
-          --SCHEDULER:New( nil, BASE.CreateEventTakeoff, { GroupSpawned, timer.getTime(), UnitSpawned:GetDCSObject() }, 5 )  --No need to create a new SCHEDULER instance every time!
-          self:ScheduleOnce(5, BASE.CreateEventTakeoff, {GroupSpawned, timer.getTime(), UnitSpawned:GetDCSObject()})
+          -- BASE:ScheduleOnce forwards its trailing args to the scheduled function as
+          -- varargs, so they must NOT be wrapped in a table here (unlike SCHEDULER:New,
+          -- which takes a single argument table). Passing a table made it argument #1,
+          -- i.e. CreateEventTakeoff ran with that table as `self`, so the takeoff event
+          -- never fired and air-spawned groups (e.g. AI_A2A_DISPATCHER GCI defenders)
+          -- never activated.
+          self:ScheduleOnce(5, BASE.CreateEventTakeoff, GroupSpawned, timer.getTime(), UnitSpawned:GetDCSObject())
         end
       end
 


### PR DESCRIPTION
`SPAWN:SpawnAtAirbase` schedules the synthetic takeoff event for air-spawned
groups as:

```lua
self:ScheduleOnce(5, BASE.CreateEventTakeoff,
                  {GroupSpawned, timer.getTime(), UnitSpawned:GetDCSObject()})
```

`BASE:ScheduleOnce(Start, SchedulerFunction, ...)` forwards its trailing
arguments to the scheduled function as **varargs** — it wraps `...` in a table
internally before handing them to the dispatcher. Wrapping the arguments in a
table at the call site makes that table **argument #1**, so `CreateEventTakeoff`
runs with the `{group, time, dcs}` table as `self`. A plain table has no `:F()`,
so the first line of the method errors, the `S_EVENT_TAKEOFF` event is never
raised, and air-spawned groups never complete activation.

Concretely: an `AI_A2A_DISPATCHER` configured with `SetDefaultTakeoffInAir()`
scrambles GCI defenders that never activate — zero interceptors fly with
`takeoff = Air`.

The sibling call site in `SpawnAtParkingSpot` is correct because it uses
`SCHEDULER:New(nil, fn, {args}, 5)`, which *does* take a single argument table.
This PR drops the braces so the args pass as varargs, producing the same call
the working sibling makes: `CreateEventTakeoff(self=group, EventTime, Initiator)`.
