### PR TITLE
Add group option change event support

### DIFF
--- a/Moose Development/Moose/Core/Base.lua
+++ b/Moose Development/Moose/Core/Base.lua
@@ -735,6 +735,12 @@ do -- Event Handling
   -- @function [parent=#BASE] OnEventPlayerEnterAircraft
   -- @param #BASE self
   -- @param Core.Event#EVENTDATA EventData The EventData structure.
+
+  --- Occurs when an option is changed for an AI group.
+  -- The event identifies the initiating group, but does not provide the option ID or value.
+  -- @function [parent=#BASE] OnEventGroupChangeOption
+  -- @param #BASE self
+  -- @param Core.Event#EVENTDATA EventData The EventData structure.
   
   --- Occurs when a player creates a dynamic cargo object from the F8 ground crew menu.
   -- *** NOTE *** this is a workarounf for DCS not creating these events as of Aug 2024.
@@ -880,6 +886,22 @@ end
   
     world.onEvent(Event)
   end  
+
+  --- Creation of a `S_EVENT_GROUP_CHANGE_OPTION` event.
+  -- @param #BASE self
+  -- @param DCS#Time EventTime The time stamp of the event.
+  -- @param DCS#Group Initiator The initiating group of the event.
+  function BASE:CreateEventGroupChangeOption( EventTime, Initiator )
+    self:F( { EventTime, Initiator } )
+
+    local Event = {
+      id = EVENTS.GroupChangeOption,
+      time = EventTime,
+      initiator = Initiator,
+    }
+
+    world.onEvent( Event )
+  end
   
     --- Creation of a S_EVENT_NEW_DYNAMIC_CARGO event.
   -- @param #BASE self

--- a/Moose Development/Moose/Core/Event.lua
+++ b/Moose Development/Moose/Core/Event.lua
@@ -278,6 +278,7 @@ EVENTS = {
   SimulationUnfreeze        = world.event.S_EVENT_SIMULATION_UNFREEZE or -1, 
   HumanAircraftRepairStart  = world.event.S_EVENT_HUMAN_AIRCRAFT_REPAIR_START or -1, 
   HumanAircraftRepairFinish = world.event.S_EVENT_HUMAN_AIRCRAFT_REPAIR_FINISH or -1,
+  GroupChangeOption         = world.event.S_EVENT_GROUP_CHANGE_OPTION or -1,
   -- dynamic cargo
   NewDynamicCargo           = world.event.S_EVENT_NEW_DYNAMIC_CARGO or -1,
   DynamicCargoLoaded        = world.event.S_EVENT_DYNAMIC_CARGO_LOADED or -1,
@@ -291,23 +292,25 @@ EVENTS = {
 --
 --   * A (Object.Category.)UNIT : A UNIT object type is involved in the Event.
 --   * A (Object.Category.)STATIC : A STATIC object type is involved in the Event.
+--   * A GROUP : A DCS Group object is involved in the Event.
 --
 -- @type EVENTDATA
 -- @field #number id The identifier of the event.
 --
--- @field DCS#Unit initiator (UNIT/STATIC/SCENERY) The initiating @{DCS#Unit} or @{DCS#StaticObject}.
+-- @field DCS#Unit initiator (UNIT/STATIC/SCENERY/GROUP) The initiating @{DCS#Unit} or @{DCS#StaticObject}. For `S_EVENT_GROUP_CHANGE_OPTION`, this is a DCS Group.
 -- @field DCS#Object.Category IniObjectCategory (UNIT/STATIC/SCENERY) The initiator object category ( Object.Category.UNIT or Object.Category.STATIC ).
 -- @field DCS#Unit IniDCSUnit (UNIT/STATIC) The initiating @{DCS#Unit} or @{DCS#StaticObject}.
 -- @field #string IniDCSUnitName (UNIT/STATIC) The initiating Unit name.
 -- @field Wrapper.Unit#UNIT IniUnit (UNIT/STATIC) The initiating MOOSE wrapper @{Wrapper.Unit#UNIT} of the initiator Unit object.
 -- @field #string IniUnitName (UNIT/STATIC) The initiating UNIT name (same as IniDCSUnitName).
--- @field DCS#Group IniDCSGroup (UNIT) The initiating {DCSGroup#Group}.
--- @field #string IniDCSGroupName (UNIT) The initiating Group name.
--- @field Wrapper.Group#GROUP IniGroup (UNIT) The initiating MOOSE wrapper @{Wrapper.Group#GROUP} of the initiator Group object.
--- @field #string IniGroupName UNIT) The initiating GROUP name (same as IniDCSGroupName).
+-- @field DCS#Group IniDCSGroup (UNIT/GROUP) The initiating @{DCS#Group}.
+-- @field #string IniDCSGroupName (UNIT/GROUP) The initiating Group name.
+-- @field Wrapper.Group#GROUP IniGroup (UNIT/GROUP) The initiating MOOSE wrapper @{Wrapper.Group#GROUP} of the initiator Group object.
+-- @field #string IniGroupName (UNIT/GROUP) The initiating GROUP name (same as IniDCSGroupName).
+-- @field DCS#Group.Category IniGroupCategory (GROUP) The category of the initiating group.
 -- @field #string IniPlayerName (UNIT) The name of the initiating player in case the Unit is a client or player slot.
 -- @field #string IniPlayerUCID (UNIT) The UCID of the initiating player in case the Unit is a client or player slot and on a multi-player server.
--- @field DCS#coalition.side IniCoalition (UNIT) The coalition of the initiator.
+-- @field DCS#coalition.side IniCoalition (UNIT/GROUP) The coalition of the initiator.
 -- @field DCS#Unit.Category IniCategory (UNIT) The category of the initiator.
 -- @field #string IniTypeName (UNIT) The type name of the initiator.
 --
@@ -734,6 +737,12 @@ local _EVENTMETA = {
      Side = "I",
      Event = "OnEventHumanAircraftRepairFinish",
      Text = "S_EVENT_HUMAN_AIRCRAFT_REPAIR_FINISH"
+   },
+     [EVENTS.GroupChangeOption] = {
+     Order = 1,
+     Side = "I",
+     Event = "OnEventGroupChangeOption",
+     Text = "S_EVENT_GROUP_CHANGE_OPTION"
    },
    -- dynamic cargo
      [EVENTS.NewDynamicCargo] = {
@@ -1234,7 +1243,16 @@ function EVENT:onEvent( Event )
 
       if Event.initiator then
 
-        Event.IniObjectCategory = Object.getCategory(Event.initiator)
+        if Event.id == EVENTS.GroupChangeOption then
+          Event.IniDCSGroup = Event.initiator
+          Event.IniDCSGroupName = Group.getName(Event.initiator)
+          Event.IniGroupName = Event.IniDCSGroupName
+          Event.IniGroup = GROUP:FindByName(Event.IniDCSGroupName)
+          Event.IniCoalition = Group.getCoalition(Event.initiator)
+          Event.IniGroupCategory = Group.getCategory(Event.initiator)
+        else
+          Event.IniObjectCategory = Object.getCategory(Event.initiator)
+        end
         
         if Event.IniObjectCategory == Object.Category.STATIC then
           ---

--- a/Moose Development/Moose/DCS.lua
+++ b/Moose Development/Moose/DCS.lua
@@ -87,7 +87,8 @@ do -- world
   -- @field S_EVENT_SIMULATION_UNFREEZE = 58 
   -- @field S_EVENT_HUMAN_AIRCRAFT_REPAIR_START = 59 
   -- @field S_EVENT_HUMAN_AIRCRAFT_REPAIR_FINISH = 60   
-  -- @field S_EVENT_MAX = 61
+  -- @field S_EVENT_GROUP_CHANGE_OPTION = 61
+  -- @field S_EVENT_MAX = 62
   
   --- The birthplace enumerator is used to define where an aircraft or helicopter has spawned in association with birth events.
   -- @type world.BirthPlace


### PR DESCRIPTION
## Summary

- add `EVENTS.GroupChangeOption` support for DCS `S_EVENT_GROUP_CHANGE_OPTION`
- normalize the event's group initiator into MOOSE group event data
- document `OnEventGroupChangeOption` and add an explicit manual event creator
- update the DCS event documentation for event 61 and `S_EVENT_MAX = 62`

## Why

DCS now emits a group option change event whose initiator is a group reference rather than a normal DCS `Object`. MOOSE did not have metadata for this event, which caused unknown-event warnings, and its normal initiator path calls `Object.getCategory`, which is not valid for this group reference.

The event identifies the affected group and event time. It does not currently expose the option ID, old value, or new value.

The event constant uses the existing `or -1` compatibility pattern so older DCS versions can continue loading MOOSE.

## Impact

Scripts can subscribe with an explicit callback or define `OnEventGroupChangeOption`. Group-scoped subscriptions work through the populated group name, wrapper, coalition, and category fields.

The manual event creator is not wired into controller option setters, avoiding duplicate callbacks when DCS emits the native event.

## Validation

- all changed Lua source files pass `loadfile`
- static and dynamic MOOSE include generation succeeds
- the generated static include passes Lua 5.1 compilation
- generated output contains the callback, creator, metadata, and normalization paths
- `git diff --check` passes
- UTF-8 without BOM and CRLF formatting are preserved
