### PR TITLE
Fix Escort follow tasks, Dynamic Cargo tracking, and MANTIS checks

### DIFF
--- a/Moose Development/Moose/Functional/Mantis.lua
+++ b/Moose Development/Moose/Functional/Mantis.lua
@@ -2043,35 +2043,31 @@ do
   -- @param #MANTIS self
   -- @param #number height
   -- @param Core.Point#COORDINATE SamCoordinate
+  -- @param #table contactSnapshot Contact facts captured once for the current check.
   -- @return #table set
-  function MANTIS:_PreFilterHeight(height,SamCoordinate)
+  function MANTIS:_PreFilterHeight(height,SamCoordinate,contactSnapshot)
     self:T(self.lid.."_PreFilterHeight")   
     local set = {}
-    local dlink = self.Detection -- Ops.Intel#INTEL_DLINK
-    local detectedgroups = dlink:GetContactTable()
-    for _,_contact in pairs(detectedgroups) do
-      local contact = _contact -- Ops.Intel#INTEL.Contact
+    for _,contact in pairs(contactSnapshot) do
       local grp = contact.group -- Wrapper.Group#GROUP
-      if grp:IsAlive() then
-        local coord = grp:GetCoordinate()
-        local dist = 0
-        local include = true
-        if grp:IsGround() then include = false end
-        if grp:IsShip() then include = false end -- MANTIS is anti-air: surface contacts are not engageable targets
-        if grp:GetCoalition() == self.coalition then include = false end
-        if coord and SamCoordinate and grp:IsHelicopter() then
-          dist = coord:Get2DDistance(SamCoordinate) or 0
-          if dist > self.ShoradActDistance then include = false end -- we do not want long range shooting at helos
-        end
-        if self.debug then
-          local text = "Looking at Group: "..grp:GetName() or "N/A"
-          text = text .. " Include = "..tostring(include)
-          MESSAGE:New(text,10,"MANTIS"):ToAllIf(self.verbose):ToLog()
-        end
-        local grpalt = grp:GetHeight(true)
-        if grpalt < height and grpalt > 10 and include == true then          
-          table.insert(set,coord)
-        end
+      local coord = contact.coordinate
+      local dist = 0
+      local include = true
+      if contact.isGround then include = false end
+      if contact.isShip then include = false end -- MANTIS is anti-air: surface contacts are not engageable targets
+      if contact.coalition == self.coalition then include = false end
+      if coord and SamCoordinate and contact.isHelicopter then
+        dist = coord:Get2DDistance(SamCoordinate) or 0
+        if dist > self.ShoradActDistance then include = false end -- we do not want long range shooting at helos
+      end
+      if self.debug then
+        local text = "Looking at Group: "..grp:GetName() or "N/A"
+        text = text .. " Include = "..tostring(include)
+        MESSAGE:New(text,10,"MANTIS"):ToAllIf(self.verbose):ToLog()
+      end
+      local grpalt = contact.height
+      if grpalt < height and grpalt > 10 and include == true then
+        table.insert(set,coord)
       end
     end
     return set
@@ -2084,16 +2080,17 @@ do
   -- @param #number radius Radius to check.
   -- @param #number height Height to check.
   -- @param #boolean dlink Data from DLINK.
+  -- @param #table contactSnapshot Contact facts captured once for the current check.
   -- @return #boolean True if in any zone, else false
   -- @return #number Distance Target distance in meters or zero when no object is in zone
-  function MANTIS:_CheckObjectInZone(dectset, samcoordinate, radius, height, dlink)
+  function MANTIS:_CheckObjectInZone(dectset, samcoordinate, radius, height, dlink, contactSnapshot)
     self:T(self.lid.."_CheckObjectInZone")
     -- check if non of the coordinate is in the given defense zone
     local rad = radius or self.checkradius
     local set = dectset
     if dlink then
       -- DEBUG
-      set = self:_PreFilterHeight(height,samcoordinate)
+      set = self:_PreFilterHeight(height,samcoordinate,contactSnapshot)
     end
     --self.friendlyset -- Core.Set#SET_GROUP
     if self.checkforfriendlies == true and self.friendlyset == nil then
@@ -2732,7 +2729,8 @@ do
         group:OptionEngageRange(engagerange)  --engagement will be 95% of firing range
         if (group:IsGround() or group:IsShip()) and group:IsAlive() then
           local grpname = group:GetName()
-          local grpcoord = group:GetCoordinate()
+          local grpcoord = group:GetCoord()
+          if grpcoord then grpcoord.Heading = group:GetHeading() or 0 end
           if group:IsShip() and self.NavalPerUnit
             and self:_BuildNavalUnitEntries(group, grpname, SAM_Tbl, SAM_Tbl_lg, SAM_Tbl_md, SAM_Tbl_sh, SAM_Tbl_pt, SEAD_Grps) then
             self:T(grpname.." handled as per-unit naval group")
@@ -2944,10 +2942,11 @@ function MANTIS:SeadAllowSuppression(targetGroup, targetName, attackerGroup, wea
   -- @param #table detset Table of COORDINATES
   -- @param #boolean dlink Using DLINK
   -- @param #number limit of SAM sites to go active on a contact
+  -- @param #table contactSnapshot Contact facts captured once for the current check.
   -- @return #number instatusred
   -- @return #number instatusgreen
   -- @return #number activeshorads
-  function MANTIS:_CheckLoop(samset,detset,dlink,limit)
+  function MANTIS:_CheckLoop(samset,detset,dlink,limit,contactSnapshot)
     self:T(self.lid .. "CheckLoop " .. #detset .. " Coordinates")
     local switchedon = 0
     local instatusred = 0
@@ -2976,7 +2975,7 @@ function MANTIS:SeadAllowSuppression(targetGroup, targetName, attackerGroup, wea
       local samalive = false
       if navalparent then samalive = (samunit ~= nil) and samunit:IsAlive() or false
       elseif samgroup then samalive = samgroup:IsAlive() or false end
-      local IsInZone, Distance = self:_CheckObjectInZone(detset, samcoordinate, radius, height, dlink)
+      local IsInZone, Distance = self:_CheckObjectInZone(detset, samcoordinate, radius, height, dlink, contactSnapshot)
       -- Naval surface wake-up: quiet ships activate when enemy surface combatants
       -- close within the trigger radius. Jamming has precedence and holds them down.
       if (not IsInZone) and self.NavalSurfaceWakeup and self._navalSAMs and self._navalSAMs[name]
@@ -3095,22 +3094,41 @@ function MANTIS:SeadAllowSuppression(targetGroup, targetName, attackerGroup, wea
       self:_RefreshSAMTable()
     end
     self.checkcounter = self.checkcounter + 1
+    local contactSnapshot = nil
+    if dlink then
+      contactSnapshot = {}
+      for _,contact in pairs(detection:GetContactTable()) do
+        local grp = contact.group -- Wrapper.Group#GROUP
+        if grp:IsAlive() then
+          local coord = grp:GetCoord()
+          contactSnapshot[#contactSnapshot + 1] = {
+            group = grp,
+            coordinate = coord,
+            height = grp:GetHeight(true),
+            coalition = grp:GetCoalition(),
+            isGround = grp:IsGround(),
+            isShip = grp:IsShip(),
+            isHelicopter = grp:IsHelicopter(),
+          }
+        end
+      end
+    end
     local instatusred = 0
     local instatusgreen = 0
     local activeshorads = 0
     -- switch SAMs on/off if (n)one of the detected groups is inside their reach
     if self.automode then
       local samset = self.SAM_Table_Long -- table of i.1=names, i.2=coordinates, i.3=firing range, i.4=firing height
-      local instatusredl, instatusgreenl, activeshoradsl = self:_CheckLoop(samset,detset,dlink,self.maxlongrange)
+      local instatusredl, instatusgreenl, activeshoradsl = self:_CheckLoop(samset,detset,dlink,self.maxlongrange,contactSnapshot)
       local samset = self.SAM_Table_Medium -- table of i.1=names, i.2=coordinates, i.3=firing range, i.4=firing height
-      local instatusredm, instatusgreenm, activeshoradsm = self:_CheckLoop(samset,detset,dlink,self.maxmidrange)
+      local instatusredm, instatusgreenm, activeshoradsm = self:_CheckLoop(samset,detset,dlink,self.maxmidrange,contactSnapshot)
       local samset = self.SAM_Table_Short -- table of i.1=names, i.2=coordinates, i.3=firing range, i.4=firing height
-      local instatusreds, instatusgreens, activeshoradss = self:_CheckLoop(samset,detset,dlink,self.maxshortrange)
+      local instatusreds, instatusgreens, activeshoradss = self:_CheckLoop(samset,detset,dlink,self.maxshortrange,contactSnapshot)
       local samset = self.SAM_Table_PointDef -- table of i.1=names, i.2=coordinates, i.3=firing range, i.4=firing height
-      local instatusred, instatusgreen, activeshorads = self:_CheckLoop(samset,detset,dlink,self.maxpointdefrange)
+      local instatusred, instatusgreen, activeshorads = self:_CheckLoop(samset,detset,dlink,self.maxpointdefrange,contactSnapshot)
     else
       local samset = self:_GetSAMTable() -- table of i.1=names, i.2=coordinates, i.3=firing range, i.4=firing height
-      local instatusred, instatusgreen, activeshorads = self:_CheckLoop(samset,detset,dlink,self.maxclassic)
+      local instatusred, instatusgreen, activeshorads = self:_CheckLoop(samset,detset,dlink,self.maxclassic,contactSnapshot)
     end
     
     local function GetReport()
@@ -4090,8 +4108,8 @@ function MANTIS:SeadAllowSuppression(targetGroup, targetName, attackerGroup, wea
   end
 
   --- [Internal] Override: _CheckLoop with jammer suppression.
-  function MANTIS:_CheckLoop(samset, detset, dlink, limit)
-    local r, g, s = self:_CheckLoopOriginal(samset, detset, dlink, limit)
+  function MANTIS:_CheckLoop(samset, detset, dlink, limit, contactSnapshot)
+    local r, g, s = self:_CheckLoopOriginal(samset, detset, dlink, limit, contactSnapshot)
     if self._jammerEnabled and self._jammedSAMs then
       for _, _data in pairs(samset) do
         local name = _data[1]

--- a/Moose Development/Moose/Ops/Auftrag.lua
+++ b/Moose Development/Moose/Ops/Auftrag.lua
@@ -6466,7 +6466,13 @@ function AUFTRAG:GetDCSMissionTask(MissionGroup)
     -- ESCORT Mission --
     --------------------
 
-    local DCStask=CONTROLLABLE.TaskEscort(nil, self.engageTarget:GetObject(), self.escortVec3, nil, self.engageMaxDistance, self.engageTargetTypes)
+    local FollowGroup=self.engageTarget:GetObject()
+    local DCStask=nil
+    if next(self.engageTargetTypes)==nil then
+      DCStask=FollowGroup:TaskFollow(FollowGroup, self.escortVec3)
+    else
+      DCStask=CONTROLLABLE.TaskEscort(nil, FollowGroup, self.escortVec3, nil, self.engageMaxDistance, self.engageTargetTypes)
+    end
 
     table.insert(DCStasks, DCStask)
     

--- a/Moose Development/Moose/Ops/CTLD.lua
+++ b/Moose Development/Moose/Ops/CTLD.lua
@@ -2748,16 +2748,14 @@ function CTLD:_EventHandler(EventData)
         loaded = self.Loaded_Cargo[unitname] -- #CTLD.LoadedCargo
         loaded.Cratesloaded = loaded.Cratesloaded - 1
         if loaded.Cratesloaded < 0  then loaded.Cratesloaded = 0 end
-        -- TODO zap cargo from list
         local Loaded = {}
         for _,_item in pairs (loaded.Cargo or {}) do
           self:T(self.lid.."UNLOAD checking: ".._item:GetName())
           self:T(self.lid.."UNLOAD state: ".. tostring(_item:WasDropped()))
-          if _item and _item:GetType() == CTLD_CARGO.Enum.GCLOADABLE and event.IniDynamicCargoName and event.IniDynamicCargoName ~= _item:GetName() and not _item:WasDropped() then
+          local unloadedItem = _item and _item:GetType() == CTLD_CARGO.Enum.GCLOADABLE and event.IniDynamicCargoName and event.IniDynamicCargoName == _item:GetName()
+          if not unloadedItem then
             table.insert(Loaded,_item)
-          else
-            table.insert(Loaded,_item)
-          end 
+          end
         end
         loaded.Cargo = nil
         loaded.Cargo = Loaded


### PR DESCRIPTION
## Summary

### Escort Missions

- Changed escort missions using an empty target list (`{}`) to use DCS's native Follow task.
- Preserved standard Escort behavior when target types are provided.
- Preserved `{"Air"}` as the default when the target argument is omitted.
- Fixed the documented “simple FOLLOW” option previously still creating an Escort task internally.

### Dynamic Cargo

- Fixed ground-crew unloaded Dynamic Cargo remaining in `Loaded_Cargo` after unloading.

### MANTIS

- Changed `_Check` to snapshot live contact data once per cycle and pass it through `_CheckLoop`, `_CheckObjectInZone`, and `_PreFilterHeight`.
- Changed `_RefreshSAMTable` to reuse group coordinates with `GetCoord()` while refreshing `Heading`.
- Preserved per-SAM helicopter-distance filtering, ship filtering, naval behavior, detection timing, emissions, relocation, and SAM limits.
