### PR TITLE
Fix option cache for reused controllable wrappers

### DIFF
--- a/Moose Development/Moose/Core/Database.lua
+++ b/Moose Development/Moose/Core/Database.lua
@@ -186,6 +186,8 @@ function DATABASE:AddUnit( DCSUnitName, force )
 
     -- Register unit
     self.UNITS[DCSunitName]=UNIT:Register(DCSunitName)
+  else
+    self.UNITS[DCSunitName]:ResetOptionCacheIfDCSObjectChanged()
   end
 
   return self.UNITS[DCSunitName]
@@ -802,6 +804,8 @@ function DATABASE:AddGroup( GroupName, force )
   if not self.GROUPS[GroupName] or force == true then
     self:T( { "Add GROUP:", GroupName } )
     self.GROUPS[GroupName] = GROUP:Register( GroupName )
+  else
+    self.GROUPS[GroupName]:ResetOptionCacheIfDCSObjectChanged()
   end
 
   return self.GROUPS[GroupName]

--- a/Moose Development/Moose/Wrapper/Controllable.lua
+++ b/Moose Development/Moose/Wrapper/Controllable.lua
@@ -3283,34 +3283,22 @@ end
 -- @param #number OptionValue Value of the option
 -- @return #CONTROLLABLE self
 function CONTROLLABLE:SetOption( OptionID, OptionValue )
-  
-  local setnewoption = false
-
-  -- Check if option has changed against cached option
   local ID = tostring(OptionID)
-  if self.ControllableOptions then
-    if (self.ControllableOptions[ID] ~= OptionValue) or (self.ControllableOptions[ID]==nil) then
-      setnewoption = true
-      self.ControllableOptions[ID] = OptionValue
-      --self:I(string.format("CONTROLLABLE %s: Option CHANGE for option %d: New value: %s!",self.ControllableName, OptionID, tostring(OptionValue)))
-    end
+  if OptionValue ~= nil and self.ControllableOptions and self.ControllableOptions[ID] == OptionValue then
+    return self
   end
-  
-  -- change option if changed
-  if setnewoption == true then    
-    local DCSControllable = self:GetDCSObject()
-    if DCSControllable then
-      local Controller = self:_GetController()
-      --self:I(string.format("CONTROLLABLE %s: Setting OPTION  %d: to value: %s!",self.ControllableName, OptionID, tostring(OptionValue)))
-      Controller:setOption( OptionID, OptionValue )
-      return self
-    end
-  --else
-    --self:I(string.format("CONTROLLABLE %s: Option NO CHANGE for option %d: Same value: %s!",self.ControllableName, OptionID, tostring(OptionValue)))     
-  end
-  
-  return nil
 
+  local DCSControllable = self:GetDCSObject()
+  if DCSControllable then
+    local Controller = DCSControllable:getController()
+    Controller:setOption( OptionID, OptionValue )
+    self.ControllableOptions = self.ControllableOptions or {}
+    self.ControllableOptions[ID] = OptionValue
+    self.ControllableOptionDCSObject = DCSControllable
+    return self
+  end
+
+  return nil
 end
 
 --- Query a (cached) option. Requires the option has been set with Moose(!) before.
@@ -3323,6 +3311,27 @@ function CONTROLLABLE:QueryCachedOption(OptionID)
     return self.ControllableOptions[ID]
   end
   return nil
+end
+
+--- Reset cached options for this controllable.
+-- @param #CONTROLLABLE self
+-- @return #CONTROLLABLE self
+function CONTROLLABLE:ResetOptionCache()
+  self.ControllableOptions = {}
+  self.ControllableOptionDCSObject = self:GetDCSObject()
+  return self
+end
+
+--- Reset cached options when the underlying DCS object has changed.
+-- @param #CONTROLLABLE self
+-- @return #CONTROLLABLE self
+function CONTROLLABLE:ResetOptionCacheIfDCSObjectChanged()
+  local DCSControllable = self:GetDCSObject()
+  if self.ControllableOptionDCSObject ~= DCSControllable then
+    self.ControllableOptions = {}
+    self.ControllableOptionDCSObject = DCSControllable
+  end
+  return self
 end
 
 --- Set option for Rules of Engagement (ROE).

--- a/Moose Development/Moose/Wrapper/Group.lua
+++ b/Moose Development/Moose/Wrapper/Group.lua
@@ -2272,9 +2272,8 @@ function GROUP:Respawn( Template, Reset )
   -- Reset events.
   self:ResetEvents()
   
-    -- Reset options
-  self.ControllableOptions = nil
-  self.ControllableOptions = {}
+  -- Reset options.
+  self:ResetOptionCache()
 
   return self
 end


### PR DESCRIPTION
Fixes the option cache when a newly spawned group reuses an existing name and MOOSE wrapper.

DATABASE:Spawn() now clears cached options on the returned group wrapper, and GROUP:Respawn() uses the same cache-reset method.